### PR TITLE
[Feature] Dark Mode

### DIFF
--- a/TCSA.V2026/Components/App.razor
+++ b/TCSA.V2026/Components/App.razor
@@ -9,14 +9,35 @@
     <link href=@Assets["_content/MudBlazor/MudBlazor.min.css"] rel="stylesheet" />
     <ImportMap />
     <link rel="icon" type="image/ico" href="favicon.ico" />
-    <HeadOutlet />
+    <HeadOutlet @rendermode="RenderModeForPage" />
 </head>
 
 <body>
-    <Routes />
+    <Routes @rendermode="RenderModeForPage" />
     <script src="_framework/blazor.web.js"></script>
     <script src=@Assets["_content/MudBlazor/MudBlazor.min.js"]></script>
     <script src=@Assets["_content/Extensions.MudBlazor.StaticInput/NavigationObserver.js"]></script>
+    <script>
+        function setCookie(cname, cvalue, exdays) {
+            const d = new Date();
+            d.setTime(d.getTime() + (exdays*24*60*60*1000));
+            let expires = "expires="+ d.toUTCString();
+            document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+        }
+    </script>
 </body>
-
 </html>
+
+@code {
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+    private IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path switch
+    {
+        var path when path.StartsWithSegments("/Account/Login", StringComparison.InvariantCultureIgnoreCase) => null,
+        var path when path.StartsWithSegments("/Account/LoginWith2fa", StringComparison.InvariantCultureIgnoreCase) => null,
+        var path when path.StartsWithSegments("/Account/LoginWithRecoveryCode", StringComparison.InvariantCultureIgnoreCase) => null,
+        var path when path.StartsWithSegments("/Account/ExternalLogin", StringComparison.InvariantCultureIgnoreCase) => null,
+        var path when path.StartsWithSegments("/Account/SignOut", StringComparison.InvariantCultureIgnoreCase) => null,
+        _ => new InteractiveServerRenderMode(prerender: false)
+    };
+}

--- a/TCSA.V2026/Components/Layout/MainLayout.razor
+++ b/TCSA.V2026/Components/Layout/MainLayout.razor
@@ -14,7 +14,7 @@
         <MudStaticNavDrawerToggle DrawerId="nav-drawer" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
         <MudText Typo="Typo.h5" Class="ml-3">Application</MudText>
         <MudSpacer />
-        <MudSwitch ValueChanged="ToggleTheme" Color="Color.Primary" Class="ma-4" T="bool" Label="Toggle Light/Dark Mode" />
+        <MudSwitch ValueChanged="ToggleTheme" Value="@ThemeService.IsDarkMode" Color="Color.Primary" Class="ma-4" T="bool" Label="Toggle Light/Dark Mode" />
     </MudAppBar>
     <MudDrawer id="nav-drawer" @bind-Open="_drawerOpen" ClipMode="DrawerClipMode.Always" Elevation="2">
         <NavMenu />

--- a/TCSA.V2026/Components/Layout/MainLayout.razor
+++ b/TCSA.V2026/Components/Layout/MainLayout.razor
@@ -1,6 +1,10 @@
-﻿@inherits LayoutComponentBase
+﻿@using TCSA.V2026.Services
+@inherits LayoutComponentBase
+@inject ThemeService ThemeService
+@inject IHttpContextAccessor HttpContextAccessor
+@inject IJSRuntime JS
 
-<MudThemeProvider />
+<MudThemeProvider @bind-IsDarkMode="@ThemeService.IsDarkMode" />
 <MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
@@ -9,6 +13,8 @@
     <MudAppBar Elevation="1">
         <MudStaticNavDrawerToggle DrawerId="nav-drawer" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
         <MudText Typo="Typo.h5" Class="ml-3">Application</MudText>
+        <MudSpacer />
+        <MudSwitch ValueChanged="ToggleTheme" Color="Color.Primary" Class="ma-4" T="bool" Label="Toggle Light/Dark Mode" />
     </MudAppBar>
     <MudDrawer id="nav-drawer" @bind-Open="_drawerOpen" ClipMode="DrawerClipMode.Always" Elevation="2">
         <NavMenu />
@@ -27,6 +33,22 @@
 
 @code {
     private bool _drawerOpen = true;
+
+    protected override void OnInitialized()
+    {
+        var themeCookie = HttpContextAccessor.HttpContext?.Request.Cookies["theme"];
+        if (themeCookie != null)
+        {
+            ThemeService.IsDarkMode = themeCookie == "dark";
+        };
+    }
+
+    private async Task ToggleTheme()
+    {
+        ThemeService.ToggleTheme();
+        // Update cookie via JS interop or via server-side endpoint.
+        await JS.InvokeVoidAsync("setCookie", "theme", ThemeService.IsDarkMode ? "dark" : "light", 365);
+    }
 }
 
 

--- a/TCSA.V2026/Program.cs
+++ b/TCSA.V2026/Program.cs
@@ -30,6 +30,9 @@ builder.Services.AddScoped<IPeerReviewService, PeerReviewService>();
 builder.Services.AddScoped<ICommunityService, CommunityService>();
 builder.Services.AddTransient<IEmailSender, EmailSender>();
 
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<ThemeService>();
+
 builder.Services.AddAuthentication(options =>
     {
         options.DefaultScheme = IdentityConstants.ApplicationScheme;

--- a/TCSA.V2026/Services/ThemeService.cs
+++ b/TCSA.V2026/Services/ThemeService.cs
@@ -1,0 +1,11 @@
+﻿namespace TCSA.V2026.Services;
+
+public sealed class ThemeService
+{
+    public bool IsDarkMode { get; set; }
+
+    public void ToggleTheme()
+    {
+        IsDarkMode = !IsDarkMode;
+    }
+}


### PR DESCRIPTION
Initial implementation of dark mode.

NOTES:
- Due to page interactivity, the theme switch does not work in the auth pages.
- Uses cookies to set and retrieve theme
- MudBlazor requires full interactivity to work. So have implemented such in `App.razor`. This may break some things.
- I noted that you prefer no prerendering

**App.razor**
![image](https://github.com/user-attachments/assets/74515ca1-6710-4527-8f97-7405782b8545)
![image](https://github.com/user-attachments/assets/6c75ca98-f152-48b6-aa5b-745688ef5b81)


**Light**
![image](https://github.com/user-attachments/assets/c8e885ac-8e59-4151-8ec2-26debad3369e)

**Dark**
![image](https://github.com/user-attachments/assets/086a0e0a-9e3e-4bdc-b262-0f7700e3d115)

**Reflected in Auth**
![image](https://github.com/user-attachments/assets/34a31122-b9ed-4e6c-a2c8-d03aa5c4cbd5)
