### PR TITLE
[Feature] Project Link in Peer Reviews

### DIFF
--- a/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
@@ -26,7 +26,11 @@
         {
             <MudDataGrid Class="mt-2" Dense="true" Items="@AvailableProjects" RowStyle="GetRowStyle">
                 <Columns>
-                    <PropertyColumn Property="p => p.Title" Title="Title" />
+                    <TemplateColumn Title="Title">
+                        <CellTemplate>
+                            <MudLink Href="@($"project/{context.Item.ProjectId}/{context.Item.ProjectSlug}")" Target="_blank">@context.Item.Title</MudLink>
+                        </CellTemplate>
+                    </TemplateColumn>
                     <PropertyColumn Property="p => p.ExperiencePoints" Title="XPs" />
                     <PropertyColumn Property="p => p.DurationOpen" Title="Open Since" />
                     <TemplateColumn CellClass="d-flex justify-end">
@@ -43,7 +47,7 @@
                                     </MudButton>
 
                                 }
-                                else 
+                                else
                                 {
                                     <MudButton Size="@Size.Small"
                                                Variant="@Variant.Filled"

--- a/TCSA.V2026/Data/DTOs/PeerReviewDisplay.cs
+++ b/TCSA.V2026/Data/DTOs/PeerReviewDisplay.cs
@@ -10,6 +10,7 @@ public class PeerReviewDisplay
     public string AppUserId { get; set; }
     public int ExperiencePoints { get; set; }
     public int ProjectId { get; set; }
+    public string ProjectSlug { get; set; }
     public int DashboardProjectId { get; set; }
     public TimeSpan DurationOpen { get; set; }
 }

--- a/TCSA.V2026/Helpers/PeerReviewHelpers.cs
+++ b/TCSA.V2026/Helpers/PeerReviewHelpers.cs
@@ -21,6 +21,7 @@ public static class PeerReviewHelpers
                 Title = project.Title,
                 IconUrl = project.IconUrl,
                 ProjectId = dp.ProjectId,
+                ProjectSlug = project.Slug,
                 Name = GetRevieweeName(dp.AppUser),
                 ExperiencePoints = project.ExperiencePoints,
                 GithubUrl = dp.GithubUrl,


### PR DESCRIPTION
Added a clickable link to the Title field in Peer Reviews.
Once clicked, the project page will open in a new tab.

Changed the Title column from a `PropertyColumn` to a `TemplateColumn` containing a `MudLink`.
Added the `Href`, which is composed of `project/{projectId}/{projectSlug}`
Added `ProjectSlug` property to `PeerReviewDisplay.cs` DTO
Added `ProjectSlug` initialiser to `PeerReviewHelper.cs`

![image](https://github.com/user-attachments/assets/63c7ba79-3454-4733-a1db-fcdb4bd7c6cb)

![image](https://github.com/user-attachments/assets/cb34f4ee-3e2a-40a8-94eb-cc1d5f25a64d)

closes #13 

Thanks,
@chrisjamiecarter 👍 