### PR TITLE
feat: add readable peer reviews duration formatting

### DIFF
--- a/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
@@ -28,7 +28,7 @@
                 <Columns>
                     <PropertyColumn Property="p => p.Title" Title="Title" />
                     <PropertyColumn Property="p => p.ExperiencePoints" Title="XPs" />
-                    <PropertyColumn Property="p => TimeSpanFormatter.FormatDurationOpen(p.DurationOpen)" Title="Open Since" />
+                    <PropertyColumn CellStyleFunc="@_durationCellStyleFunc" Property="p => TimeSpanFormatter.FormatDurationOpen(p.DurationOpen)" Title="Open Since" />
                     <TemplateColumn CellClass="d-flex justify-end">
                         <CellTemplate>
                             <MudStack Row>
@@ -162,4 +162,6 @@
 
         AvailableProjects = await PeerReviewService.GetProjectsForPeerReview(UserId);
     }
+
+    private Func<PeerReviewDisplay, string> _durationCellStyleFunc => p => p.DurationOpen.TotalDays > 7 ? "color: red" : "";
 }

--- a/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
@@ -28,7 +28,7 @@
                 <Columns>
                     <PropertyColumn Property="p => p.Title" Title="Title" />
                     <PropertyColumn Property="p => p.ExperiencePoints" Title="XPs" />
-                    <PropertyColumn Property="p => p.DurationOpen" Title="Open Since" />
+                    <PropertyColumn Property="p => TimeSpanFormatter.FormatDurationOpen(p.DurationOpen)" Title="Open Since" />
                     <TemplateColumn CellClass="d-flex justify-end">
                         <CellTemplate>
                             <MudStack Row>

--- a/TCSA.V2026/Helpers/TimeSpanFormatter.cs
+++ b/TCSA.V2026/Helpers/TimeSpanFormatter.cs
@@ -1,0 +1,25 @@
+﻿using Humanizer;
+
+namespace TCSA.V2026.Helpers;
+
+public static class TimeSpanFormatter
+{
+    public static string FormatDurationOpen(TimeSpan duration)
+    {
+        var days = duration.Days;
+        var hours = duration.Hours;
+        var minutes = duration.Minutes;
+
+        var formattedDuration = duration switch
+        {
+            { Hours: > 0, Days: > 0 } => $"{"day".ToQuantity(days)} {"hour".ToQuantity(hours)} ago",
+            { Days: > 0 } => $"{"day".ToQuantity(days)} ago",
+            { Minutes: > 0, Hours: > 0 } => $"{"hour".ToQuantity(hours)} {"minute".ToQuantity(minutes)} ago",
+            { Hours: > 0 } => $"{"hour".ToQuantity(hours)} ago",
+            { Minutes: > 0 } => $"{"minute".ToQuantity(minutes)} ago",
+            _ => "just now"
+        };
+
+        return formattedDuration;
+    }
+}


### PR DESCRIPTION
#### Summary
This PR improves the "Open Since" column by displaying peer review durations in a more user-friendly format. Additionally, if a peer review project has been open for more than 7 days, the duration text is highlighted in red.

#### Changes
- Added `TimeSpanFormatter` for displaying durations in a human-readable format using the Humanizer library
- Improved the readability of the 'Open Since' column by utilizing the `TimeSpanFormatter`
- Applied conditional styling to the 'Open Since' column to highlight priority for peer review projects open for more than 7 days

![image](https://github.com/user-attachments/assets/e1e0b0d0-22b1-4ab5-8523-7fda7447b8bf)
