### PR TITLE
feat: add leaderboard mobile responsiveness

### DIFF
--- a/TCSA.V2026/Components/Pages/Dashboard/Leaderboard.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Leaderboard.razor
@@ -51,7 +51,7 @@
                         </TemplateColumn>
                         <TemplateColumn Title="Country" HeaderStyle="font-weight:bold" CellClass="pa-2 pa-md-3" HeaderClass="pa-2 pa-md-3">
                             <CellTemplate>
-                                <MudStack Row="true" AlignItems="AlignItems.Center">
+                                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
                                     <MudImage ObjectFit="ObjectFit.Contain" Width="30" Src="@FlagHelper.GetFlag(context.Item.Country)" Alt="..." />
                                     <MudText Class="d-none d-sm-inline" Style="font-weight:bold" Typo="Typo.subtitle1">@context.Item.Country</MudText>
                                 </MudStack>
@@ -60,27 +60,39 @@
                     </Columns>
                 </MudDataGrid>
             } else {
-                <MudDataGrid Class="mt-2" Dense="true" Items="@ReviewUsers">
+                <MudDataGrid Class="mt-2" Dense="true" Items="@ReviewUsers" Breakpoint="Breakpoint.None">
                     <Columns>
-                        <PropertyColumn Property="u => u.Ranking" Title="Pos" CellStyle="font-weight:bold" HeaderStyle="font-weight:bold" />
-                        <PropertyColumn Property="u => u.DisplayName" Title="Name" CellStyle="font-weight:bold" HeaderStyle="font-weight:bold" />
-                        <TemplateColumn Title="Country" HeaderStyle="font-weight:bold">
+                        <TemplateColumn Title="Pos" HeaderStyle="font-weight:bold" CellClass="pa-2 pa-md-3" HeaderClass="pa-2 pa-md-3">
+                            <CellTemplate>
+                                <MudText Style="font-weight:bold" Typo="Typo.subtitle1">@context.Item.Ranking</MudText>
+                            </CellTemplate>
+                        </TemplateColumn>
+                        <TemplateColumn Title="Name" HeaderStyle="font-weight:bold" CellClass="pa-2 pa-md-3" HeaderClass="pa-2 pa-md-3">
+                            <CellTemplate>
+                                <MudText Style="font-weight:bold" Typo="Typo.subtitle1">@context.Item.DisplayName</MudText>
+                            </CellTemplate>
+                        </TemplateColumn>
+                        <TemplateColumn Title="Country" HeaderStyle="font-weight:bold" CellClass="pa-2 pa-md-3" HeaderClass="pa-2 pa-md-3">
                             <CellTemplate>
                                 <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
                                     <MudImage ObjectFit="ObjectFit.Contain" Width="30" Src="@FlagHelper.GetFlag(context.Item.Country)" Alt="..." />
-                                    <MudText Style="font-weight:bold" Typo="Typo.subtitle1">@context.Item.Country</MudText>
+                                    <MudText Class="d-none d-sm-inline" Style="font-weight:bold" Typo="Typo.subtitle1">@context.Item.Country</MudText>
                                 </MudStack>
                             </CellTemplate>
                         </TemplateColumn>
-                        <TemplateColumn Title="Total XP" HeaderStyle="font-weight:bold">
+                        <TemplateColumn Title="Total XP" HeaderStyle="font-weight:bold" CellClass="pa-2 pa-md-3" HeaderClass="pa-2 pa-md-3">
                             <CellTemplate>
                                 <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
                                     <MudImage ObjectFit="ObjectFit.Contain" Width="30" Src="img/experience.png" />
-                                    <MudText Style="font-weight:bold" Typo="Typo.subtitle1">@context.Item.TotalXp</MudText>
+                                    <MudText Style="font-weight:bold" Typo="Typo.subtitle2">@context.Item.TotalXp</MudText>
                                 </MudStack>
                             </CellTemplate>
                         </TemplateColumn>
-                        <PropertyColumn Title="Total Reviews" Property="u => u.ReviewsNumber" CellStyle="font-weight:bold" HeaderStyle="font-weight:bold" />
+                        <TemplateColumn Title="Total Reviews" HeaderStyle="font-weight:bold" CellClass="pa-2 pa-md-3" HeaderClass="pa-2 pa-md-3">
+                            <CellTemplate>
+                                <MudText Style="font-weight:bold" Typo="Typo.subtitle1">@context.Item.ReviewsNumber</MudText>
+                            </CellTemplate>
+                        </TemplateColumn>
                     </Columns>
                 </MudDataGrid>
             }

--- a/TCSA.V2026/Components/Pages/Dashboard/Leaderboard.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Leaderboard.razor
@@ -8,10 +8,9 @@
 @attribute [Authorize]
 
 <PageTitle>Leaderboard</PageTitle>
-<MudContainer>
+<MudContainer Class="pa-0">
     <DashboardToolBar></DashboardToolBar>
-    <MudButton
-        FullWidth="true" Variant="Variant.Filled" Color="Color.Primary" Class="mb-4" OnClick="FilterReviews">
+    <MudButton FullWidth="true" Variant="Variant.Filled" Color="Color.Primary" Class="mb-4" OnClick="FilterReviews">
         Click to see @(IsReviews ? "All Time" : "Reviews") Leaderboard
     </MudButton>
 
@@ -24,11 +23,16 @@
         <MudText>LoadTime: @LoadTime.TotalSeconds.ToString()</MudText>
         if (Users != null && Users.Count > 0)
         {
-            if (!IsReviews) {
-                <MudDataGrid Class="mt-2" Dense="true" Items="@Users">
+            if (!IsReviews)
+            {
+                <MudDataGrid Class="mt-2" Dense="true" Items="@Users" Breakpoint="Breakpoint.None">
                     <Columns>
-                        <PropertyColumn Property="u => u.Ranking" Title="Pos" CellStyle="font-weight:bold" HeaderStyle="font-weight:bold" />
-                        <TemplateColumn Title="XPs" HeaderStyle="font-weight:bold">
+                        <TemplateColumn Title="Pos" HeaderStyle="font-weight:bold" CellClass="pa-2 pa-md-3" HeaderClass="pa-2 pa-md-3">
+                            <CellTemplate>
+                                <MudText Style="font-weight:bold" Typo="Typo.subtitle1">@context.Item.Ranking</MudText>
+                            </CellTemplate>
+                        </TemplateColumn>
+                        <TemplateColumn Title="XPs" HeaderStyle="font-weight:bold" CellClass="pa-2 pa-md-3" HeaderClass="pa-2 pa-md-3">
                             <CellTemplate>
                                 <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
                                     <MudImage ObjectFit="ObjectFit.Contain" Width="30" Src="img/experience.png" />
@@ -36,7 +40,7 @@
                                 </MudStack>
                             </CellTemplate>
                         </TemplateColumn>
-                        <TemplateColumn Title="Name" HeaderStyle="font-weight:bold">
+                        <TemplateColumn Title="Name" HeaderStyle="font-weight:bold" CellClass="pa-2 pa-md-3" HeaderClass="pa-2 pa-md-3">
                             <CellTemplate>
                                 <MudText Style="font-weight:bold" Typo="Typo.subtitle1">@context.Item.DisplayName</MudText>
                                 <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
@@ -45,11 +49,11 @@
                                 </MudStack>
                             </CellTemplate>
                         </TemplateColumn>
-                        <TemplateColumn Title="Country" HeaderStyle="font-weight:bold">
+                        <TemplateColumn Title="Country" HeaderStyle="font-weight:bold" CellClass="pa-2 pa-md-3" HeaderClass="pa-2 pa-md-3">
                             <CellTemplate>
                                 <MudStack Row="true" AlignItems="AlignItems.Center">
                                     <MudImage ObjectFit="ObjectFit.Contain" Width="30" Src="@FlagHelper.GetFlag(context.Item.Country)" Alt="..." />
-                                    <MudText Style="font-weight:bold" Typo="Typo.subtitle1">@context.Item.Country</MudText>
+                                    <MudText Class="d-none d-sm-inline" Style="font-weight:bold" Typo="Typo.subtitle1">@context.Item.Country</MudText>
                                 </MudStack>
                             </CellTemplate>
                         </TemplateColumn>


### PR DESCRIPTION
#### Summary  
This PR adds mobile-responsive styling to the users and reviews leaderboards, ensuring they display correctly on smaller devices.

#### Changes
- Updated `<MudDataGrid>` components to include `Breakpoint="Breakpoint.None"` for consistent responsiveness.   
- Enhanced column styling with `CellClass`, `HeaderClass`, and typography updates for better visual consistency.

#### Before & After

##### Users Leaderboard
| Before | After |
| -------|--------|
| ![image](https://github.com/user-attachments/assets/a989727a-5408-447e-a3f9-0d0c6358bdb1) | ![image](https://github.com/user-attachments/assets/08a881f9-3383-46c6-927f-067a29e387de) |

##### Reviews Leaderboard
| Before | After |
| -------|--------|
| ![image](https://github.com/user-attachments/assets/813615c5-becb-497c-973b-ddc01f22639d) |  ![image](https://github.com/user-attachments/assets/3087b271-0877-4913-be8e-8e52f433a4c4) |
