### PR TITLE
test: add unit tests

### DIFF
--- a/TCSA.V2026.UnitTests/Helpers/TimeSpanFormatterTests.cs
+++ b/TCSA.V2026.UnitTests/Helpers/TimeSpanFormatterTests.cs
@@ -1,0 +1,25 @@
+﻿using TCSA.V2026.Helpers;
+
+namespace TCSA.V2026.UnitTests.Helpers;
+
+[TestFixture]
+public class TimeSpanFormatterTests
+{
+    [TestCase(0, 0, 0, 0, "just now")]
+    [TestCase(2, 3, 0, 0, "2 days 3 hours ago")]
+    [TestCase(1, 0, 0, 0, "1 day ago")]
+    [TestCase(0, 2, 30, 0, "2 hours 30 minutes ago")]
+    [TestCase(0, 1, 0, 0, "1 hour ago")]
+    [TestCase(0, 0, 5, 30, "5 minutes ago")]
+    public void FormatDurationOpen_ShouldReturnCorrectFormat(int days, int hours, int minutes, int seconds, string expected)
+    {
+        // Arrange
+        var duration = new TimeSpan(days, hours, minutes, seconds);
+
+        // Act
+        var result = TimeSpanFormatter.FormatDurationOpen(duration);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(expected));
+    }
+}

--- a/TCSA.V2026.UnitTests/TCSA.V2026.UnitTests.csproj
+++ b/TCSA.V2026.UnitTests/TCSA.V2026.UnitTests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TCSA.V2026\TCSA.V2026.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>

--- a/TCSA.V2026.sln
+++ b/TCSA.V2026.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.12.35527.113
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TCSA.V2026", "TCSA.V2026\TCSA.V2026.csproj", "{CCBDF791-D024-42EF-B277-DD8362832EA8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TCSA.V2026.UnitTests", "TCSA.V2026.UnitTests\TCSA.V2026.UnitTests.csproj", "{5369024E-AC90-4B46-B8E0-E3363913B04A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{CCBDF791-D024-42EF-B277-DD8362832EA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CCBDF791-D024-42EF-B277-DD8362832EA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CCBDF791-D024-42EF-B277-DD8362832EA8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5369024E-AC90-4B46-B8E0-E3363913B04A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5369024E-AC90-4B46-B8E0-E3363913B04A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5369024E-AC90-4B46-B8E0-E3363913B04A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5369024E-AC90-4B46-B8E0-E3363913B04A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
 #### Summary  
Introduced a new unit test project to validate the `TimeSpanFormatter` functionality.

#### Changes
- Added unit tests for `TimeSpanFormatter.FormatDurationOpen`.  
- Configured the test project with `.NET 9.0` and `NUnit`.  
- Integrated the new test project into the solution.  
