### PR TITLE
fix: ensure display name is shown on leaderboard

### DIFF
--- a/TCSA.V2026.UnitTests/Helpers/UserDisplayNameHelperTests.cs
+++ b/TCSA.V2026.UnitTests/Helpers/UserDisplayNameHelperTests.cs
@@ -1,0 +1,28 @@
+﻿using TCSA.V2026.Data.Models;
+using TCSA.V2026.Helpers;
+
+namespace TCSA.V2026.UnitTests.Helpers;
+
+[TestFixture]
+public class UserDisplayNameHelperTests
+{
+    [TestCase("John Doe", "John Doe", "John Doe")]
+    [TestCase(null, "johndoe@example.com", "johndoe")]
+    [TestCase(null, null, "Anonymous")]
+    [TestCase("John Doe", null, "John Doe")]
+    public void GetDisplayName_ShouldReturnDisplayName(string? displayName, string? userName, string expected)
+    {
+        // Arrange
+        var user = new ApplicationUser
+        {
+            DisplayName = displayName,
+            UserName = userName
+        };
+
+        // Act
+        string result = UserDisplayNameHelper.GetDisplayName(user);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(expected));
+    }
+}

--- a/TCSA.V2026/Helpers/UserDisplayNameHelper.cs
+++ b/TCSA.V2026/Helpers/UserDisplayNameHelper.cs
@@ -1,0 +1,22 @@
+﻿using TCSA.V2026.Data.Models;
+
+namespace TCSA.V2026.Helpers;
+
+public static class UserDisplayNameHelper
+{
+    public static string GetDisplayName(ApplicationUser user)
+    {
+        if (!string.IsNullOrWhiteSpace(user.DisplayName))
+        {
+            return user.DisplayName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(user.UserName))
+        {
+            int atIndex = user.UserName.IndexOf('@');
+            return atIndex > 0 ? user.UserName.Substring(0, atIndex) : user.UserName;
+        }
+
+        return "Anonymous";
+    }
+}

--- a/TCSA.V2026/Services/LeaderboardService.cs
+++ b/TCSA.V2026/Services/LeaderboardService.cs
@@ -4,6 +4,7 @@ using System.Data;
 using TCSA.V2026.Data;
 using TCSA.V2026.Data.DTOs;
 using TCSA.V2026.Data.Models;
+using TCSA.V2026.Helpers;
 using TCSA.V2026.Helpers.Constants;
 
 namespace TCSA.V2026.Services;
@@ -45,7 +46,7 @@ public class LeaderboardService : ILeaderboardService
                     {
                         Id = user.Id,
                         Country = user.Country,
-                        DisplayName = user.DisplayName,
+                        DisplayName = UserDisplayNameHelper.GetDisplayName(user),
                         TotalXp = user.ReviewExperiencePoints,
                         ReviewsNumber = user.CodeReviewProjects.Count()
                     };
@@ -105,7 +106,7 @@ public class LeaderboardService : ILeaderboardService
                 Id = user.Id,
                 Country = user.Country,
                 Level = user.Level,
-                DisplayName = user.DisplayName,
+                DisplayName = UserDisplayNameHelper.GetDisplayName(user),
                 ExperiencePoints = user.ExperiencePoints,
                 Ranking = index
             };


### PR DESCRIPTION
#### Summary  
This PR introduces a reusable helper and updates leaderboard logic to ensure user display names are correctly shown.

#### Changes
- Added `UserDisplayNameHelper` with `GetDisplayName` method for determining user display names.  
- Added unit tests for `GetDisplayName` covering various scenarios.  
- Updated `LeaderboardService` to use this helper in `UserReviewLeaderboardDisplay` and `UserLeaderboardDisplay`

![image](https://github.com/user-attachments/assets/12d7b25a-c313-49f5-8c47-15043a6069eb)

