### PR TITLE
style: update home page cards to have equal heights

### DIFF
--- a/TCSA.V2026/Components/Pages/Home.razor
+++ b/TCSA.V2026/Components/Pages/Home.razor
@@ -46,8 +46,8 @@
         @foreach (var article in Articles.Where(x => x.Area == Area.StartHere))
         {
             <MudItem xs="12" sm="6" md="3">
-                <MudCard>
-                    <MudCardContent Class="d-flex justify-center mt-4">
+                <MudCard Style="height: 100%;">
+                    <MudCardContent Class="d-flex justify-center mt-4 flex-grow-0">
                         <MudImage Src="@($"img/icons/{article.IconUrl}")"
                         Alt="@article.Title"
                         Style="width: 100px; height: 100px; object-fit: cover;" />
@@ -56,7 +56,7 @@
                         <MudText Class="mb-3" Align="Align.Center" Typo="Typo.h5">@article.Title</MudText>
                         <MudText Typo="Typo.body2">@article.Description</MudText>
                     </MudCardContent>
-                    <MudCardContent Class="d-flex justify-center mt-4">
+                    <MudCardContent Class="d-flex justify-center mt-4 flex-grow-0">
                         <MudButton Class=""
                         Size="@Size.Medium"
                         Variant="@Variant.Filled"
@@ -83,8 +83,8 @@
         @foreach (var p in Projects.Where(x => x.Area == Area.Console && x.Id != 52 && x.Id != 75))
         {
             <MudItem xs="12" sm="6" md="3">
-                <MudCard>
-                    <MudCardContent Class="d-flex justify-center mt-4">
+                <MudCard Style="height: 100%;">
+                    <MudCardContent Class="d-flex justify-center mt-4 flex-grow-0">
                         <MudImage Src="@($"img/icons/{p.IconUrl}")"
                         Alt="@p.Title"
                         Style="width: 100px; height: 100px; object-fit: cover;" />
@@ -93,7 +93,7 @@
                         <MudText Class="mb-3" Align="Align.Center" Typo="Typo.h5">@p.Title</MudText>
                         <MudText Align="Align.Center" Typo="Typo.body2">@p.Description</MudText>
                     </MudCardContent>
-                    <MudCardContent Class="d-flex justify-center mt-2">
+                    <MudCardContent Class="d-flex justify-center mt-2 flex-grow-0">
                         <MudButton Class=""
                         Size="@Size.Medium"
                         Variant="@Variant.Filled"
@@ -132,8 +132,8 @@
             @foreach (var p in a.Projects)
             {
                 <MudItem xs="12" sm="6" md="3">
-                    <MudCard>
-                        <MudCardContent Class="d-flex justify-center mt-4">
+                    <MudCard Style="height: 100%;">
+                        <MudCardContent Class="d-flex justify-center mt-4 flex-grow-0">
                             <MudImage Src="@($"img/icons/{p.IconUrl}")"
                                       Alt="@p.Title"
                                       Style="width: 100px; height: 100px; object-fit: cover;" />
@@ -142,7 +142,7 @@
                             <MudText Class="mb-3" Align="Align.Center" Typo="Typo.h5">@p.Title</MudText>
                             <MudText Typo="Typo.body2">@p.Description</MudText>
                         </MudCardContent>
-                        <MudCardContent Class="d-flex justify-center mt-2">
+                        <MudCardContent Class="d-flex justify-center mt-2 flex-grow-0">
                             <MudButton Class=""
                                        Size="@Size.Medium"
                                        Variant="@Variant.Filled"


### PR DESCRIPTION
#### Summary
This pull request updates the styling and structure of `MudCard` components in `Home.razor` to make their heights equal.

#### Changes
- Set `MudCard` height to `100%` and added `flex-grow-0` to `MudCardContent`.

#### Before
![image](https://github.com/user-attachments/assets/ea552789-51c5-499c-8d47-7729d3b3719c)

#### After
![image](https://github.com/user-attachments/assets/19497051-4b34-434a-8436-617ba24d486d)
