### PR TITLE
feat: improve styling of challenges page

### DIFF
--- a/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
@@ -17,12 +17,52 @@
         <MudText>LoadTime: @LoadTime.TotalSeconds.ToString()</MudText>
         if (ChallengesList != null && ChallengesList.Count > 0)
         {
-            <MudDataGrid Class="mt-2" Dense="true" Items="@ChallengesList" RowStyle="GetRowStyle">
-                <Columns>
-                    <PropertyColumn Property="x => x.Name" Title="Total XPs" />
-                    <PropertyColumn Property="x => x.ExperiencePoints" Title="XPs" />
-                </Columns>
-            </MudDataGrid>
+            <MudStack Row Class="mt-6 mb-4" Spacing="2">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary">
+                    Show Completed Challenges
+                </MudButton>
+                <MudSelect T="Level" Label="Filter by Level" Class="flex-grow-0">
+                    @foreach (Level item in Enum.GetValues(typeof(Level)))
+                    {
+                        <MudSelectItem Value="@item">@item.ToString()</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudStack>
+            <MudStack Spacing="4">
+                @foreach (var challenge in ChallengesList)
+                {
+                    <MudPaper Elevation="3" Outlined="false" Class="py-3 px-4 px-md-5">
+                        <MudStack Row Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Breakpoint="Breakpoint.Xs">
+                            <MudStack Row Spacing="5">
+                                <MudImage ObjectFit="ObjectFit.Contain" Width="60" Src="@($"img/belts/{challenge.Level}-belt.png")" />
+                                <MudStack Spacing="1">
+                                    <MudText Style="font-weight:bolder" Typo="Typo.subtitle1" Class="mud-primary-text">@challenge.Name</MudText>
+                                    <MudText Typo="Typo.body2">@challenge.Description</MudText>
+                                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                                        <MudImage ObjectFit="ObjectFit.Contain" Width="30" Src="img/experience.png" />
+                                        <MudText Style="font-weight:bolder" Typo="Typo.subtitle2">@challenge.ExperiencePoints</MudText>
+                                    </MudStack>
+                                </MudStack>
+                            </MudStack>
+                            <MudStack Row Spacing="2">
+                                <MudButton Size="@Size.Small"
+                                           Variant="@Variant.Filled"
+                                           Color="@Color.Warning"
+                                           StartIcon="fas fa-eye">
+                                    View
+                                </MudButton>
+                                <MudButton Size="@Size.Small"
+                                           Variant="@Variant.Filled"
+                                           Color="@Color.Primary"
+                                           StartIcon="@Icons.Material.Filled.Cached">
+                                    Synchronize
+                                </MudButton>
+                            </MudStack>
+                        </MudStack>
+                    </MudPaper>
+                }
+            </MudStack>
+            <MudPagination Class="mt-3 justify-center" Style="width: 100%;" Count="ChallengesList.Count" />
         }
     }
 </MudContainer>

--- a/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
@@ -7,6 +7,39 @@
 
 <MudContainer>
     <DashboardToolBar></DashboardToolBar>
+    <MudStack Row Class="mt-4" Spacing="4" Breakpoint="Breakpoint.Xs">
+        <MudPaper Class="flex-grow-1 pb-3" Elevation="3" Outlined="false">
+            <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="py-3 px-4 px-md-5" Style="@($"background-color:{Colors.Green.Lighten1}")">
+                <i class="fas fa-check-circle fa-3x" style="color: white;" />
+                <MudText Typo="Typo.subtitle1" Style="font-weight: bold; color: white;">COMPLETED</MudText>
+            </MudStack>
+            <MudStack Spacing="0" AlignItems="AlignItems.Center" Class="px-4 px-md-5">
+                <MudText Style="font-size: 2.5rem; font-weight: bolder;">@completedChallenges.Count</MudText>
+                <MudText Style="font-size: 1.25rem;">Challenges</MudText>
+            </MudStack>
+        </MudPaper>
+        <MudPaper Class="flex-grow-1 pb-3" Elevation="3" Outlined="false">
+            <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="py-3 px-4 px-md-5" Style="@($"background-color:{Colors.Red.Default}")">
+                <i class="fas fa-fire fa-3x" style="color: white;" />
+                <MudText Typo="Typo.subtitle1" Style="font-weight: bold; color: white;">STREAK</MudText>
+            </MudStack>
+            <MudStack Spacing="0" AlignItems="AlignItems.Center" Class="px-4 px-md-5">
+                <MudText Style="font-size: 2.5rem; font-weight: bolder;">12</MudText>
+                <MudText Style="font-size: 1.25rem;">Days</MudText>
+                <MudText Typo="Typo.caption">Best: 30 days</MudText>
+            </MudStack>
+        </MudPaper>
+        <MudPaper Class="flex-grow-1 pb-3" Elevation="3" Outlined="false">
+            <MudStack AlignItems="AlignItems.Center" Spacing="2" Class="py-3 px-4 px-md-5" Style="@($"background-color:{Colors.Yellow.Darken1}")">
+                <MudImage ObjectFit="ObjectFit.Contain" Width="42" Src="img/experience.png" />
+                <MudText Typo="Typo.subtitle1" Style="font-weight: bold; color: white;">XP POINTS</MudText>
+            </MudStack>
+            <MudStack Spacing="0" AlignItems="AlignItems.Center" Class="px-4 px-md-5">
+                <MudText Style="font-size: 2.5rem; font-weight: bolder;">2450</MudText>
+                <MudText Style="font-size: 1.25rem;">XP</MudText>
+            </MudStack>
+        </MudPaper>
+    </MudStack>
 
     @if (IsLoading)
     {


### PR DESCRIPTION
#### Summary
This PR introdues a new layout for displaying challenges, replacing the previous data grid. This update also adds a new section for displaying completed challenges, streaks and XP points.

#### Changes
- Included a button for toggling completed challenges (functionality to be implemented later).
- Added a dropdown for filtering challenges by level (functionality to be implemented later).
- Replaced the data grid with a stripe-based layout.
- Created a new section to showcase completed challenges, streaks and XP earned.

![image](https://github.com/user-attachments/assets/3582282a-d8c1-4174-82f7-8841f4a08a90)
![image](https://github.com/user-attachments/assets/c2075145-695c-4eb4-9864-61fa099a74b9)
![image](https://github.com/user-attachments/assets/e7e39728-1b19-4b8f-a2f7-9e913ac895c9)

