### PR TITLE
test: add unit tests for FlagHelper class

### DIFF
--- a/TCSA.V2026.UnitTests/Helpers/FlagHelperTests.cs
+++ b/TCSA.V2026.UnitTests/Helpers/FlagHelperTests.cs
@@ -1,0 +1,19 @@
+﻿using TCSA.V2026.Helpers;
+
+namespace TCSA.V2026.UnitTests.Helpers;
+
+[TestFixture]
+public class FlagHelperTests
+{
+    public void GetFlag_ShouldReturnEarthImage_WhenCountryIsNullOrEmpty()
+    {
+        // Arrange
+        string country = null;
+
+        // Act
+        var result = FlagHelper.GetFlag(country);
+
+        // Assert
+        Assert.That(result, Is.EqualTo("img/flags/earth.png"));
+    }
+}

--- a/TCSA.V2026.UnitTests/Helpers/FlagHelperTests.cs
+++ b/TCSA.V2026.UnitTests/Helpers/FlagHelperTests.cs
@@ -35,7 +35,7 @@ public class FlagHelperTests
     [TestCase("United Kingdom", "img/flags/united-kingdom.png")]
     [TestCase("United States", "img/flags/united-states.png")]
     [TestCase("Brazil", "img/flags/brazil.png")]
-    public void GetFlag_ShouldReturnCorrectFlagImagePath_WhenCountryExists(string country, string expected)
+    public void GetFlag_ShouldReturnCorrectFlagImage_WhenCountryExists(string country, string expected)
     {
         // Act
         var result = FlagHelper.GetFlag(country);

--- a/TCSA.V2026.UnitTests/Helpers/FlagHelperTests.cs
+++ b/TCSA.V2026.UnitTests/Helpers/FlagHelperTests.cs
@@ -5,10 +5,24 @@ namespace TCSA.V2026.UnitTests.Helpers;
 [TestFixture]
 public class FlagHelperTests
 {
+    [Test]
     public void GetFlag_ShouldReturnEarthImage_WhenCountryIsNullOrEmpty()
     {
         // Arrange
         string country = null;
+
+        // Act
+        var result = FlagHelper.GetFlag(country);
+
+        // Assert
+        Assert.That(result, Is.EqualTo("img/flags/earth.png"));
+    }
+
+    [Test]
+    public void GetFlag_ShouldReturnEarthImage_WhenCountryNotFound()
+    {
+        // Arrange
+        string country = "Unknown Country";
 
         // Act
         var result = FlagHelper.GetFlag(country);

--- a/TCSA.V2026.UnitTests/Helpers/FlagHelperTests.cs
+++ b/TCSA.V2026.UnitTests/Helpers/FlagHelperTests.cs
@@ -30,4 +30,17 @@ public class FlagHelperTests
         // Assert
         Assert.That(result, Is.EqualTo("img/flags/earth.png"));
     }
+
+    [TestCase("Canada", "img/flags/canada.png")]
+    [TestCase("United Kingdom", "img/flags/united-kingdom.png")]
+    [TestCase("United States", "img/flags/united-states.png")]
+    [TestCase("Brazil", "img/flags/brazil.png")]
+    public void GetFlag_ShouldReturnCorrectFlagImagePath_WhenCountryExists(string country, string expected)
+    {
+        // Act
+        var result = FlagHelper.GetFlag(country);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(expected));
+    }
 }


### PR DESCRIPTION
#### Summary
The changes introduce a new test class `FlagHelperTests` that validates the behavior of the `FlagHelper` methods.

#### Changes
- Added tests to check the return values for null, unknown, and known country inputs to ensure correct flag image retrieval.
