### PR TITLE
feat: show friendly message when there are no notifications

### DIFF
--- a/TCSA.V2026/Components/UI/TCSANotificationDialog.razor
+++ b/TCSA.V2026/Components/UI/TCSANotificationDialog.razor
@@ -4,17 +4,26 @@
         @MudDialog.Title
     </TitleContent>
     <DialogContent>
-        <MudStack>
-            @foreach (var n in Notifications)
-            {
-                <MudPaper Elevation="2" Class="pa-2 my-1">
-                    <div style="display: flex; align-items: center; gap: 8px;">
-                        <MudImage Src="@GetIcon(n.Description, n.IconUrl)" Width="30" Class="mr-3"/>
-                        <MudText>@n.Description</MudText>
-                    </div>
-                </MudPaper>
-            }
-        </MudStack>
+        @if (Notifications != null && Notifications.Any())
+        {
+            <MudStack>
+                @foreach (var n in Notifications)
+                {
+                    <MudPaper Elevation="2" Class="pa-2 my-1">
+                        <div style="display: flex; align-items: center; gap: 8px;">
+                            <MudImage Src="@GetIcon(n.Description, n.IconUrl)" Width="30" Class="mr-3" />
+                            <MudText>@n.Description</MudText>
+                        </div>
+                    </MudPaper>
+                }
+            </MudStack>
+        } else
+        {
+            <MudText Typo="Typo.body1">
+                You don’t have any notifications at the moment. Enjoy your day!
+            </MudText>
+        }
+
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>


### PR DESCRIPTION
#### Summary
This PR improves the notification display. If no notifications are present, a friendly message is displayed to inform the user.

#### Changes
- `TCSANotificationDialog.razor`: Added conditional check for `Notifications` and a message for empty notifications.

![image](https://github.com/user-attachments/assets/dad5b0a6-e381-4aae-b47f-ff9da0fa9aae)

