### PR TITLE
feat: implement filtering challenges by level

### DIFF
--- a/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
@@ -54,12 +54,12 @@
         <MudText>LoadTime: @LoadTime.TotalSeconds.ToString()</MudText>
         if (ChallengesList != null && ChallengesList.Count > 0)
         {
-            <MudStack Row Class="mt-6 mb-4" Spacing="2">
+            <MudStack Row Class="mt-6 mb-4" Spacing="4" AlignItems="AlignItems.Center">
                 <MudCheckBox @bind-Value="@_showCompleted"
                 Label="Show Completed"
                 CheckedIcon="@Icons.Material.Outlined.CheckBox"
                 UncheckedIcon="@Icons.Material.Outlined.CheckBoxOutlineBlank" />
-                <MudSelect T="Level" Label="Filter by Level" Class="flex-grow-0">
+                <MudSelect T="Level" Label="Filter by Level" Placeholder="Level" Class="flex-grow-0" MultiSelection="true" @bind-SelectedValues="_selectedLevels">
                     @foreach (Level item in Enum.GetValues(typeof(Level)))
                     {
                         <MudSelectItem Value="@item">@item.ToString()</MudSelectItem>
@@ -111,21 +111,25 @@
 </MudContainer>
 
 @code {
-    [Inject] private NavigationManager Navigation { get; set; }
-    [Inject] private AuthenticationStateProvider AuthenticationState { get; set; }
-    [Inject] private IChallengeService ChallengeService { get; set; }
-    [Inject] private ICodewarsService CodewarsService { get; set; }
-    [Inject] private IUserService UserService { get; set; }
+        [Inject] private NavigationManager Navigation { get; set; }
+        [Inject] private AuthenticationStateProvider AuthenticationState { get; set; }
+        [Inject] private IChallengeService ChallengeService { get; set; }
+        [Inject] private ICodewarsService CodewarsService { get; set; }
+        [Inject] private IUserService UserService { get; set; }
 
-    [Inject] private IJSRuntime JS { get; set; }
-    [Inject] private ISnackbar Snackbar { get; set; }
+        [Inject] private IJSRuntime JS { get; set; }
+        [Inject] private ISnackbar Snackbar { get; set; }
 
     private List<Challenge> ChallengesList = new();
     private List<int> CompletedChallenges = new();
     private ApplicationUser User { get; set; }
     private List<Challenge> FilteredChallenges =>
-        _showCompleted ? ChallengesList.Where(c => IsCompleted(c.Id)).ToList() : ChallengesList;
+        ChallengesList.Where(c =>
+            (!_showCompleted || IsCompleted(c.Id)) &&
+            (!_selectedLevels.Any() || _selectedLevels.Contains(c.Level))
+        ).ToList();
 
+    private IEnumerable<Level> _selectedLevels = new HashSet<Level>();
     private bool _showCompleted = false;
     private bool IsLoading = true;
     private string UserId = string.Empty;


### PR DESCRIPTION
#### Summary
The pull request implements filtering challenges by level and enchances spacing between the filters.

#### Changes
- Adjusted spacing between filters and added alignment properties.
- Enhanced `MudSelect` with a placeholder and multi-selection capability for level filtering.
- Modified filtering logic to account for both completion status and selected levels.

![image](https://github.com/user-attachments/assets/38087e9f-3ff0-4445-9c53-1b5a4b6f6db1)
![image](https://github.com/user-attachments/assets/0c33457c-b4dc-4eaa-8761-5499133ce9df)
![image](https://github.com/user-attachments/assets/98f3fb38-7bd1-4921-a7bb-0dc000a19c0b)

