### PR TITLE
fix: correct text color in dark mode on project pages

### DIFF
--- a/TCSA.V2026/Components/Pages/ProjectPage.razor
+++ b/TCSA.V2026/Components/Pages/ProjectPage.razor
@@ -50,7 +50,7 @@
                                 <MudListItem>
                                     <div style="display: flex;">
                                         <MudIcon Icon="@Icons.Material.Filled.CheckBox" Color="Color.Success" Class="mr-2" />
-                                        <MudText Style="color: black;">@((MarkupString)(req))</MudText>
+                                        <MudText>@((MarkupString)(req))</MudText>
                                     </div>
                                 </MudListItem>
                             }
@@ -68,7 +68,7 @@
                         @foreach (var item in Project.LearningItems)
                         {
                             <MudListItem>
-                                <MudText Style="color: black;" Class="mt-2">@((MarkupString)(item))</MudText>
+                                <MudText Class="mt-2">@((MarkupString)(item))</MudText>
                             </MudListItem>
                         }
                     </MudList>
@@ -86,7 +86,7 @@
                             <MudListItem>
                                 <div style="display: flex;">
                                     <MudIcon Icon="@Icons.Material.Filled.ArrowCircleRight" Color="Color.Primary" Class="mr-2" />
-                                    <MudText Style="color: black;">@((MarkupString)(item))</MudText>
+                                    <MudText>@((MarkupString)(item))</MudText>
                                 </div>
                             </MudListItem>
                         }
@@ -105,7 +105,7 @@
                             <MudListItem>
                                 <div style="display: flex;">
                                     <MudIcon Icon="@Icons.Material.Filled.CheckBox" Size="Size.Medium" Color="Color.Warning" Class="mr-2" />
-                                    <MudText Style="color: black;">@((MarkupString)(tip))</MudText>
+                                    <MudText>@((MarkupString)(tip))</MudText>
                                 </div>
                             </MudListItem>
                         }
@@ -120,7 +120,7 @@
                             <MudListItem>
                                 <div style="display: flex;">
                                     <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Size="Size.Medium" Color="Color.Error" Class="mr-2" />
-                                    <MudText Style="color: black;">@((MarkupString)(challenge))</MudText>
+                                    <MudText>@((MarkupString)(challenge))</MudText>
                                 </div>
                             </MudListItem>
                         }

--- a/TCSA.V2026/Components/Pages/ProjectPage.razor
+++ b/TCSA.V2026/Components/Pages/ProjectPage.razor
@@ -44,7 +44,7 @@
                     }
                     @if (Project.Requirements != null)
                     {
-                        <MudList ReadOnly="true" T="MarkupString">
+                        <MudList ReadOnly="true" T="MarkupString" Color="Color.Default">
                             @foreach (var req in Project.Requirements)
                             {
                                 <MudListItem>
@@ -64,7 +64,7 @@
                     {
                         <MudText Class="mt-2 mb-2">@((MarkupString)(Project.LearningIntro))</MudText>
                     }
-                    <MudList Class="mt-2" T="MarkupString">
+                    <MudList Class="mt-2" T="MarkupString" Color="Color.Default">
                         @foreach (var item in Project.LearningItems)
                         {
                             <MudListItem>
@@ -80,7 +80,7 @@
                     {
                         <MudText Class="mt-2 mb-2">@((MarkupString)(Project.ResourcesIntro))</MudText>
                     }
-                    <MudList T="MarkupString">
+                    <MudList T="MarkupString" Color="Color.Default">
                         @foreach (var item in Project.Resources)
                         {
                             <MudListItem>
@@ -99,7 +99,7 @@
                 @if (Project.Tips != null)
                 {
                     <MudText Class="mt-10 mb-2" Typo="Typo.h6">@Project.LanguageHeadings.Tips</MudText>
-                    <MudList T="MarkupString">
+                    <MudList T="MarkupString" Color="Color.Default">
                         @foreach (var tip in Project.Tips)
                         {
                             <MudListItem>
@@ -114,7 +114,7 @@
                 @if (Project.Challenges != null)
                 {
                     <MudText Class="mt-10 mb-2" Typo="Typo.h6">@Project.LanguageHeadings.Challenges</MudText>
-                    <MudList T="MarkupString">
+                    <MudList T="MarkupString" Color="Color.Default">
                         @foreach (var challenge in Project.Challenges)
                         {
                             <MudListItem>


### PR DESCRIPTION
#### Summary
This pull request fixes the text color issue in dark mode on the project pages.

#### Changes
- Added `Color.Default` to multiple `<MudList>` components in `ProjectPage.razor`.
- Removed `Style="color: black;"` from `<MudText>` components within lists in `ProjectPage.razor`.

#### Before
![image](https://github.com/user-attachments/assets/2e8f37d4-e772-438a-b0dc-8510538649f1)

#### After
![image](https://github.com/user-attachments/assets/e3188f65-0846-416f-9fda-c20987a6a4ef)

