### PR TITLE
refactor: update article cards interaction and styling

### DIFF
--- a/TCSA.V2026/Components/Pages/Articles.razor
+++ b/TCSA.V2026/Components/Pages/Articles.razor
@@ -15,13 +15,15 @@
             @foreach (var article in ArticlesList)
             {
                 <MudItem xs="12" sm="6" md="3">
-                    <MudCard Style="height:100%">
-                        <MudCardMedia Image="@($"img/cardimages/{article.CardImgUrl}")" Height="200" />
-                        <MudCardContent>
-                            <MudText Typo="Typo.h5" Style="margin-bottom:5px">@article.Title</MudText>
-                            <MudText Typo="Typo.body2">@article.Description</MudText>
-                        </MudCardContent>
-                    </MudCard>
+                    <MudLink OnClick="@(() => NavigateToArticle(article))">
+                        <MudCard Style="height:100%" Elevation="3">
+                            <MudCardMedia Image="@($"img/cardimages/{article.CardImgUrl}")" Height="200" />
+                            <MudCardContent>
+                                <MudText Typo="Typo.h5" Style="margin-bottom:5px">@article.Title</MudText>
+                                <MudText Typo="Typo.body2">@article.Description</MudText>
+                            </MudCardContent>
+                        </MudCard>
+                    </MudLink>
                 </MudItem>
             }
         </MudGrid>

--- a/TCSA.V2026/Components/Pages/Articles.razor
+++ b/TCSA.V2026/Components/Pages/Articles.razor
@@ -21,16 +21,6 @@
                             <MudText Typo="Typo.h5" Style="margin-bottom:5px">@article.Title</MudText>
                             <MudText Typo="Typo.body2">@article.Description</MudText>
                         </MudCardContent>
-                        <MudCardActions>
-                            <MudButton Class=""
-                            Size="@Size.Medium"
-                            Variant="@Variant.Filled"
-                            Color="Color.Primary"
-                            StartIcon="fas fa-eye"
-                            OnClick="@(() => NavigateToArticle(article))">
-                                View Article
-                            </MudButton>
-                        </MudCardActions>
                     </MudCard>
                 </MudItem>
             }


### PR DESCRIPTION
#### Summary
This PR refactors the article cards by removing the button and making the entire card clickable. It also increases the shadow around the card to improve its visual prominence.

#### Changes
- Removed the button from the article cards.
- Made the entire card clickable.
- Increased the card’s shadow to make it stand out better against the background.

#### Before
![image](https://github.com/user-attachments/assets/e2952cc7-62f8-491c-8b62-c30800678053)

#### After
![image](https://github.com/user-attachments/assets/dcfde695-f6b5-4c26-a0ad-85b47cc2339f)
