### PR TITLE
fix: enable theme toggle for static login/register pages

### DIFF
--- a/TCSA.V2026/Components/Account/Pages/Login.razor
+++ b/TCSA.V2026/Components/Account/Pages/Login.razor
@@ -75,6 +75,13 @@
     </MudItem>
 </MudGrid>
 
+<script src="js/theme-toggle.js"></script>
+<script>
+    window.addEventListener('DOMContentLoaded', () => {
+        window.initializeThemeToggle?.();
+    });
+</script>
+
 @code {
     private string? errorMessage;
 

--- a/TCSA.V2026/Components/Account/Pages/Register.razor
+++ b/TCSA.V2026/Components/Account/Pages/Register.razor
@@ -79,6 +79,13 @@
     </MudItem>
 </MudGrid>
 
+<script src="js/theme-toggle.js"></script>
+<script>
+    window.addEventListener('DOMContentLoaded', () => {
+        window.initializeThemeToggle?.();
+    });
+</script>
+
 @code {
     private IEnumerable<IdentityError>? identityErrors;
 

--- a/TCSA.V2026/Components/App.razor
+++ b/TCSA.V2026/Components/App.razor
@@ -49,6 +49,15 @@
             let expires = "expires="+ d.toUTCString();
             document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
         }
+
+        function getCookie(name) {
+            const cookies = document.cookie.split(';');
+            for (let cookie of cookies) {
+                const [key, value] = cookie.trim().split('=');
+                if (key === name) return value;
+            }
+            return null;
+        }
     </script>
 </body>
 </html>

--- a/TCSA.V2026/Components/Layout/MainLayout.razor
+++ b/TCSA.V2026/Components/Layout/MainLayout.razor
@@ -14,7 +14,8 @@
         <MudStaticNavDrawerToggle DrawerId="nav-drawer" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
         <MudImage Src="/img/logo.png" Width="40" />
         <MudSpacer />
-        <MudSwitch 
+        <MudSwitch
+            UserAttributes="@(new Dictionary<string, object> { ["id"] = "theme-toggle" })"
             ThumbIcon="@Icons.Material.Outlined.ModeNight"
             ValueChanged="ToggleTheme" 
             Value="@ThemeService.IsDarkMode" 

--- a/TCSA.V2026/wwwroot/js/theme-toggle.js
+++ b/TCSA.V2026/wwwroot/js/theme-toggle.js
@@ -1,0 +1,14 @@
+﻿window.initializeThemeToggle = function () {
+    const isDark = getCookie("theme") === "dark";
+    const toggle = document.getElementById("theme-toggle");
+
+    if (toggle) {
+        toggle.checked = isDark;
+
+        toggle.addEventListener("change", function () {
+            const darkMode = toggle.checked;
+            setCookie("theme", darkMode ? "dark" : "light", 365);
+            location.reload();
+        });
+    }
+};


### PR DESCRIPTION
#### Summary
This pull request fixes a theme toggle across static rendered Login and Register pages.

#### Changes
- `Login.razor` and `Register.razor`: Added script to include `theme-toggle.js` for initializing theme toggle on DOM load.
- `App.razor`: Introduced `getCookie` function to retrieve cookie values for theme management.
- `MainLayout.razor`: Modified `MudSwitch` component to include ID for theme toggling.
- `theme-toggle.js`: Defined `initializeThemeToggle` function to manage theme state and handle toggle changes.
