### PR TITLE
refactor: streamline login layout with MudStack components for better responsiveness

### DIFF
--- a/TCSA.V2026/Components/Account/Pages/Login.razor
+++ b/TCSA.V2026/Components/Account/Pages/Login.razor
@@ -13,67 +13,33 @@
 
 <PageTitle>Log in</PageTitle>
 
-<MudGrid Class="pa-5">
-    <MudItem md="4">
-        <MudGrid Class="pr-5">
-            <MudItem md="12">
-                <StatusMessage Message="@errorMessage" />
-                <EditForm Model="Input" method="post" OnValidSubmit="LoginUser" FormName="login">
-                    <DataAnnotationsValidator />
-
-                    <MudText GutterBottom="true" Typo="Typo.body1">Login with email and password</MudText>
-
-                    <MudGrid>
-                        <MudItem md="12">
-                            <MudStaticTextField For="@(() => Input.Email)" @bind-Value="Input.Email"
-                                                Label="Email" Placeholder="name@example.com"
-                                                UserAttributes="@(new() { { "autocomplete", "username" }, { "aria-required", "true" } } )" />
-                        </MudItem>
-                        <MudItem md="12">
-                            <MudStaticTextField For="@(() => Input.Password)" @bind-Value="Input.Password"
-                                                Label="Password" InputType="InputType.Password" Placeholder="password"
-                                                UserAttributes="@(new() { { "autocomplete", "current-password" }, { "aria-required", "true" } } )" />
-                        </MudItem>
-                        <MudItem md="12">
-                            <MudStaticButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" FormAction="FormAction.Submit">Log in</MudStaticButton>
-                        </MudItem>
-                    </MudGrid>
-                </EditForm>
-
-                <MudGrid>
-                    <MudItem md="12">
-                        <MudLink 
-                            Class="d-flex justify-center mt-3" 
-                            Href="/Account/ForgotPassword">Forgot your password?</MudLink><br />
-                        <MudLink 
-                            Style="margin-top: -20px;"
-                            Class="d-flex justify-center" 
-                            Href="@(NavigationManager.GetUriWithQueryParameters("Account/Register", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))">Don't have an account? Register.</MudLink>
-                            <br />
-                    </MudItem>
-                </MudGrid>
-            </MudItem>
-
-            <MudItem md="12" Class="d-flex justify-center align-center">
-                <MudText GutterBottom="true" Typo="Typo.h6">OR</MudText>
-            </MudItem>
-
-            <MudItem md="12" Class="d-flex justify-center">
-                <MudGrid>
-                    <MudItem md="12" Class="d-flex justify-center align-center">
-                        <MudText GutterBottom="true" Typo="Typo.body1">Login with your Github Account</MudText>
-                    </MudItem>
-                    <MudItem md="12" Class="d-flex justify-center align-center">
-                        <ExternalLoginPicker />
-                    </MudItem>
-                </MudGrid>
-            </MudItem>
-        </MudGrid>
-    </MudItem>
-    <MudItem md="8" Class="flex-grow-1 d-flex align-center justify-center no-scroll">
-       @*  <MudText Typo="Typo.h4" Class="text-white">Welcome to the Dashboard</MudText> *@
-    </MudItem>
-</MudGrid>
+<MudStack Class="pa-5" Row Breakpoint="Breakpoint.Xs" Justify="Justify.Center" Spacing="10" AlignItems="AlignItems.Center">
+    <MudStack Spacing="4">
+        <StatusMessage Message="@errorMessage" />
+        <EditForm Model="Input" method="post" OnValidSubmit="LoginUser" FormName="login">
+            <MudStack Spacing="4">
+                <DataAnnotationsValidator />
+                <MudText GutterBottom="true" Typo="Typo.body1">Login with email and password</MudText>
+                <MudStaticTextField For="@(() => Input.Email)" @bind-Value="Input.Email"
+                                    Label="Email" Placeholder="name@example.com"
+                                    UserAttributes="@(new() { { "autocomplete", "username" }, { "aria-required", "true" } } )" />
+                <MudStaticTextField For="@(() => Input.Password)" @bind-Value="Input.Password"
+                                    Label="Password" InputType="InputType.Password" Placeholder="password"
+                                    UserAttributes="@(new() { { "autocomplete", "current-password" }, { "aria-required", "true" } } )" />
+                <MudStaticButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" FormAction="FormAction.Submit">Log in</MudStaticButton>
+            </MudStack>
+        </EditForm>
+        <MudLink Href="/Account/ForgotPassword">Forgot your password?</MudLink>
+        <MudLink Href="@(NavigationManager.GetUriWithQueryParameters("Account/Register", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))">Don't have an account? Register.</MudLink>
+    </MudStack>
+    <MudText GutterBottom="true" Typo="Typo.h6">OR</MudText>
+    <MudStack Spacing="4" Justify="Justify.Center">
+        <MudText GutterBottom="true" Typo="Typo.body1">Login with your Github Account</MudText>
+        <div class="d-flex justify-center">
+            <ExternalLoginPicker />
+        </div>
+    </MudStack>
+</MudStack>
 
 <script src="js/theme-toggle.js"></script>
 <script>


### PR DESCRIPTION
#### Summary
The pull request improves login form layout by replacing `<MudGrid>` and `<MudItem>` components with a more organized `<MudStack>` structure, enhancing visual clarity and responsiveness.

#### Changes
- Updated layout to use `<MudStack>` for better organization and spacing.
- Simplified links for password recovery and registration.
- Adjusted placement of "OR" text and GitHub login section within the new layout.

#### Before
![image](https://github.com/user-attachments/assets/36825037-395d-464f-b9b8-b950fac70078)

#### After
![image](https://github.com/user-attachments/assets/0a453450-dba2-48ad-a7ca-b35793bcf24e)
![image](https://github.com/user-attachments/assets/be8360c3-10e8-4230-b5b7-03ba5a2f3655)

