### PR TITLE
refactor: streamline register layout with MudStack components for better responsiveness

### DIFF
--- a/TCSA.V2026/Components/Account/Pages/Register.razor
+++ b/TCSA.V2026/Components/Account/Pages/Register.razor
@@ -22,62 +22,37 @@
 
 <PageTitle>Register</PageTitle>
 
-<MudGrid Class="pa-5">
-    <MudItem md="4">
-        <MudGrid Class="pr-5">
-            <MudItem md="12">
-                <StatusMessage Message="@Message" />
-                <EditForm Model="Input" asp-route-returnUrl="@ReturnUrl" method="post" OnValidSubmit="RegisterUser" FormName="register">
-                    <DataAnnotationsValidator />
-
-                    <MudText Typo="Typo.body1" GutterBottom="true">Create a new account with e-mail and password</MudText>
-
-                    <MudGrid>
-                        <MudItem md="12">
-                            <MudStaticTextField For="@(() => Input.DisplayName)" @bind-Value="Input.DisplayName"
-                                                Label="DisplayName" Placeholder="display name"
-                                                UserAttributes="@(new() { { "autocomplete", "displayname" }, { "aria-required", "true" } } )" />
-                        </MudItem>
-                        <MudItem md="12">
-                            <MudStaticTextField For="@(() => Input.Email)" @bind-Value="Input.Email"
-                                                Label="Email" Placeholder="name@example.com"
-                                                UserAttributes="@(new() { { "autocomplete", "username" }, { "aria-required", "true" } } )" />
-                        </MudItem>
-                        <MudItem md="12">
-                            <MudStaticTextField For="@(() => Input.Password)" @bind-Value="Input.Password"
-                                                Label="Password" InputType="InputType.Password" Placeholder="password"
-                                                UserAttributes="@(new() { { "autocomplete", "new-password" }, { "aria-required", "true" } } )" />
-                        </MudItem>
-                        <MudItem md="12">
-                            <MudStaticTextField For="@(() => Input.ConfirmPassword)" @bind-Value="Input.ConfirmPassword"
-                                                Label="Confirm Password" InputType="InputType.Password" Placeholder="confirm password"
-                                                UserAttributes="@(new() { { "autocomplete", "new-password" }, { "aria-required", "true" } } )" />
-                        </MudItem>
-                        <MudItem md="12">
-                            <MudStaticButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" FormAction="FormAction.Submit">Register</MudStaticButton>
-                        </MudItem>
-                    </MudGrid>
-                </EditForm>
-            </MudItem>
-            <MudItem md="12" Class="d-flex justify-center align-center">
-                <MudText GutterBottom="true" Typo="Typo.h6">OR</MudText>
-            </MudItem>
-            <MudItem md="12" Class="d-flex justify-center">
-                <MudGrid>
-                    <MudItem md="12" Class="d-flex justify-center align-center">
-                        <MudText GutterBottom="true" Typo="Typo.body1">Register with your Github Account</MudText>
-                    </MudItem>
-                    <MudItem md="12" Class="d-flex justify-center align-center">
-                        <ExternalLoginPicker />
-                    </MudItem>
-                </MudGrid>
-            </MudItem>
-        </MudGrid>
-    </MudItem>
-    <MudItem md="8" Class="flex-grow-1 d-flex align-center justify-center no-scroll">
-        @*  <MudText Typo="Typo.h4" Class="text-white">Welcome to the Dashboard</MudText> *@
-    </MudItem>
-</MudGrid>
+<MudStack Class="pa-5" Row Breakpoint="Breakpoint.Xs" Justify="Justify.Center" Spacing="10" AlignItems="AlignItems.Center">
+    <MudStack Spacing="4">
+        <StatusMessage Message="@Message" />
+        <EditForm Model="Input" asp-route-returnUrl="@ReturnUrl" method="post" OnValidSubmit="RegisterUser" FormName="register">
+            <MudStack Spacing="4">
+                <DataAnnotationsValidator />
+                <MudText Typo="Typo.body1" GutterBottom="true">Create a new account with e-mail and password</MudText>
+                <MudStaticTextField For="@(() => Input.DisplayName)" @bind-Value="Input.DisplayName"
+                                    Label="DisplayName" Placeholder="display name"
+                                    UserAttributes="@(new() { { "autocomplete", "displayname" }, { "aria-required", "true" } } )" />
+                <MudStaticTextField For="@(() => Input.Email)" @bind-Value="Input.Email"
+                                    Label="Email" Placeholder="name@example.com"
+                                    UserAttributes="@(new() { { "autocomplete", "username" }, { "aria-required", "true" } } )" />
+                <MudStaticTextField For="@(() => Input.Password)" @bind-Value="Input.Password"
+                                    Label="Password" InputType="InputType.Password" Placeholder="password"
+                                    UserAttributes="@(new() { { "autocomplete", "new-password" }, { "aria-required", "true" } } )" />
+                <MudStaticTextField For="@(() => Input.ConfirmPassword)" @bind-Value="Input.ConfirmPassword"
+                                    Label="Confirm Password" InputType="InputType.Password" Placeholder="confirm password"
+                                    UserAttributes="@(new() { { "autocomplete", "new-password" }, { "aria-required", "true" } } )" />
+                <MudStaticButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" FormAction="FormAction.Submit">Register</MudStaticButton>
+            </MudStack>
+        </EditForm>
+    </MudStack>
+    <MudText GutterBottom="true" Typo="Typo.h6">OR</MudText>
+    <MudStack Spacing="4" Justify="Justify.Center">
+        <MudText GutterBottom="true" Typo="Typo.body1">Register with your Github Account</MudText>
+        <div class="d-flex justify-center">
+            <ExternalLoginPicker />
+        </div>
+    </MudStack>
+</MudStack>
 
 <script src="js/theme-toggle.js"></script>
 <script>


### PR DESCRIPTION
#### Summary
The pull request improves register form layout by replacing `<MudGrid>` and `<MudItem>` components with a more organized `<MudStack>` structure, enhancing visual clarity and responsiveness.

#### Changes
- Updated layout to use <MudStack> for better organization and spacing.
- Adjusted placement of "OR" text and GitHub login section within the new layout.

#### Before
![image](https://github.com/user-attachments/assets/fa6918e5-0641-450c-8b25-ca45bf712d65)

#### After
![image](https://github.com/user-attachments/assets/86ca0bb9-ff18-4cbc-a7b4-a7a36a57ed92)
![image](https://github.com/user-attachments/assets/fc0f8e17-69ad-4dd6-b8ef-e4caf57670bd)
