### PR TITLE
fix: adjust course image sizing on mobile devices

### DIFF
--- a/TCSA.V2026/Components/Pages/Dashboard/CourseDetail.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/CourseDetail.razor
@@ -52,7 +52,7 @@
                         else if (paragraph.IsPicture)
                         {
                             var imageSrc = $"img/courseimages/{paragraph.PictureUrl}";
-                            <MudPaper Class="d-flex justify-center photo-paragraph my-2 py-10 px-20" Elevation="0">
+                            <MudPaper Class="d-flex justify-center photo-paragraph my-2 py-10 px-5 px-sm-20" Elevation="0">
                                 <MudImage Src="@imageSrc" Alt="Course image" Fluid="true" />
                             </MudPaper>
                         }


### PR DESCRIPTION
#### Summary
This pull request adjusts course image sizing to ensure proper display on mobile devices.

#### Changes
- `CourseDetail.razor`: Changed padding from `px-20` to `px-5 px-sm-20` for better responsiveness on mobile devices.

#### Preview
Before | After
------- | -----
![image](https://github.com/user-attachments/assets/c7dfb736-185b-42a0-97e9-895776dc9a8d) | ![image](https://github.com/user-attachments/assets/397edc08-1f12-4d4b-bc73-c30635f96965)


