### PR TITLE
fix: adjust text color on course details page

### DIFF
--- a/TCSA.V2026/Components/Layout/MainLayout.razor
+++ b/TCSA.V2026/Components/Layout/MainLayout.razor
@@ -68,10 +68,12 @@
                 Primary = "#1C236D",
                 Secondary = "#832A77",
                 AppbarBackground = "#C9436E",
+                SuccessLighten = "#E0FFE0",
             },
             PaletteDark = new PaletteDark()
             {
-                Primary = Colors.Blue.Lighten1
+                Primary = Colors.Blue.Lighten1,
+                SuccessLighten = "#00A344",
             },
         };
 }

--- a/TCSA.V2026/Components/Pages/Dashboard/CourseDetail.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/CourseDetail.razor
@@ -19,7 +19,7 @@
                     {
                         var article = Course.Articles[i];
                         <MudListItem Text=@($"{i + 1}. {article.Title}")
-                        Style=@(CompletedProjects.Contains(article.Id) ? "background-color: #e0ffe0;" : null)
+                        Style=@(CompletedProjects.Contains(article.Id) ? "background-color: var(--mud-palette-success-lighten);" : null)
                         OnClick="@(() => NavigateToArticle(article.CourseDisplayId.Value, article.Id))" />
                     }
                 </MudList>


### PR DESCRIPTION
#### Summary
This pull request enhances the color palette by adding new success color properties and adjusts text color on course details page by using CSS variable with color from the palette.

#### Changes
- `MainLayout.razor`: Added `SuccessLighten` properties to both `PaletteLight` and `PaletteDark`.
- `CourseDetail.razor`: Updated `MudListItem` background color to use a CSS variable instead of a hardcoded value.

#### Before
![image](https://github.com/user-attachments/assets/f1e5ef8c-41dd-4019-86aa-8b83ec61707f)

#### After
![image](https://github.com/user-attachments/assets/12710153-3bc6-4123-8a89-1f5e1a404826)
