### PR TITLE
fix/#157-Removed text-decoration: underline styling from ArticlePage

### DIFF
--- a/TCSA.V2026/Components/Pages/ArticlePage.razor
+++ b/TCSA.V2026/Components/Pages/ArticlePage.razor
@@ -178,7 +178,6 @@
 <style>
     a {
         color: #1976d2; /* Material blue */
-        text-decoration: underline;
     }
 </style>
 


### PR DESCRIPTION
Removed text-decoration: underline styling from ArticlePage.
Issue #157 
