### PR TITLE
Change ternary operatory to a simple return statement for returning the savedFlight entity

### DIFF
--- a/TCSA.V2026/Data/Curriculum/Courses/WebApiCourse.cs
+++ b/TCSA.V2026/Data/Curriculum/Courses/WebApiCourse.cs
@@ -695,9 +695,9 @@ public class WebApiCourse
                                 {
                                      new Paragraph {
                                          IsCode = true,
-                                         Body = "public Flight? GetFlightById(int id)\r\n    {\r\n        Flight savedFlight = _dbContext.Flights.Find(id);\r\n        return savedFlight == null ? null : savedFlight;\r\n    }" },
+                                         Body = "public Flight? GetFlightById(int id)\r\n    {\r\n        Flight savedFlight = _dbContext.Flights.Find(id);\r\n        return savedFlight;\r\n    }" },
                                      new Paragraph {
-                                       Body = "Here we're looking for a Flight with the id provided. We use a <b>ternary expression</b> to return null if no flight was found and return the flight object if it was found."
+                                       Body = "Here we're looking for a Flight with the id provided and the entity is returned which can be null if it's not found."
                                     },
                                 },
                             },


### PR DESCRIPTION
In the Get Flight by Id section of article 8 covering Service Implementation of the Web API Course, a ternary expression was being used to return the savedFlight entity or null depending on the value of savedFlight which was unnecessary as it can be refactored into a simple return statement achieving the same result.

The necessary changes were also made to the accompanying paragraph.