### PR TITLE
Fix article banner issue91

### DIFF
--- a/TCSA.V2026/Components/Pages/Dashboard/Dashboard.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Dashboard.razor
@@ -169,7 +169,7 @@
             if (status == ResponseStatus.Success)
             {
                 User = await UserService.GetUserById(UserId);
-                await RebuildDashboardAfterProjectSubmission();
+                await BuildAreasWithProjects();
             }
         }
     }
@@ -190,11 +190,15 @@
         var claims = AuthSate.User;
         UserId = claims.FindFirstValue(ClaimTypes.NameIdentifier);
         User = await UserService.GetUserById(UserId);
+
+        await BuildAreasWithProjects();
+
+    }
+
+    private async Task BuildAreasWithProjects()
+    {
         CompletedProjects = User?.DashboardProjects?.Where(x => x.IsCompleted).Select(x => x.ProjectId).ToList();
         PendingProjects = User?.DashboardProjects?.Where(x => x.IsPendingReview).Select(x => x.ProjectId).ToList();
-
-        IsFccCompleted = CompletedProjects.Contains(75);
-        IsFccPending = PendingProjects.Contains(75);
 
         Areas = DashboardProjectsHelpers.GetAreas(CompletedProjects, PendingProjects);
 
@@ -212,29 +216,7 @@
                 Area = fcc.Area
             }
         );
+
+
     }
-
-    private async Task RebuildDashboardAfterProjectSubmission()
-    {
-        CompletedProjects = User?.DashboardProjects?.Where(x => x.IsCompleted).Select(x => x.ProjectId).ToList();
-        PendingProjects = User?.DashboardProjects?.Where(x => x.IsPendingReview).Select(x => x.ProjectId).ToList();
-
-        Areas = DashboardProjectsHelpers.GetAreas(CompletedProjects, PendingProjects);
-
-        var fcc = DashboardProjectsHelpers.Projects.FirstOrDefault(x => x.Id == 75);
-        var cp = DashboardProjectsHelpers.Articles.FirstOrDefault(x => x.Id == 9);
-
-        Areas.FirstOrDefault(x => x.Area == Area.StartHere).Tasks.AddRange(
-            new DashboardTaskDisplay
-                {
-                    Id = 75,
-                    IconUrl = fcc.IconUrl,
-                    Slug = fcc.Slug,
-                    Title = fcc.Title,
-                    Status = DashboardProjectsHelpers.GetTaskStatus(fcc.Id, CompletedProjects, PendingProjects),
-                    Area = fcc.Area
-                }
-        );
-    }
-
 }


### PR DESCRIPTION
Issue caused by Areas not being updated with completed projects once submitted, added new method BuildAreasWithProjects that is called in OnInitializedAsync and after project is submitted successfully, refresh seems to work fine when manually testing, but this was somewhat limited in scope.