### PR TITLE
fix: show current address when updating pull request url

### DIFF
--- a/TCSA.V2026/Components/UI/TCSASubmitProjectDialog.razor
+++ b/TCSA.V2026/Components/UI/TCSASubmitProjectDialog.razor
@@ -1,4 +1,4 @@
-﻿@using TCSA.V2026.Data.Models
+@using TCSA.V2026.Data.Models
 @using TCSA.V2026.Data.Models.Responses
 @using TCSA.V2026.Services
 <MudDialog Style="min-width: 400px;">
@@ -13,12 +13,12 @@
             Don't submit your own repository, <a href="https://thecsharpacademy.com/article/52/code-reviews" target="_blank"><span style="color:red; !important">read this article</span></a> to find out how to create a pull request.
         </MudText>
         <MudTextField 
-            @bind-Value="GithubUrl"
-            Error="@HasError"
-            ErrorText="@ErrorText"
-            Immediate="true"
-            OnBlur="ValidateUrl"
-            Label=@(ProjectId == 75 ? "Freecodecamp URL" : "GithubUrl") />
+        @bind-Value="GithubUrl"
+        Error="@HasError"
+        ErrorText="@ErrorText"
+        Immediate="true"
+        OnBlur="ValidateUrl"
+        Label=@(ProjectId == 75 ? "Freecodecamp URL" : "GithubUrl") />
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
@@ -39,6 +39,11 @@
     private bool HasError;
 
     private string RequiredPrefix = "https://github.com/TheCSharpAcademy/CodeReviews";
+
+    protected override void OnParametersSet()
+    {
+        GithubUrl = User.DashboardProjects.FirstOrDefault(p => p.ProjectId == ProjectId)?.GithubUrl ?? string.Empty;
+    }
 
     private void ValidateUrl()
     {


### PR DESCRIPTION
#### Summary
This pull request updates the `TCSASubmitProjectDialog.razor` to show current address when updating pull request url.

#### Changes
- `TCSASubmitProjectDialog.razor`: Introduced the `OnParametersSet` method to initialize `GithubUrl`.

#### Preview
https://github.com/user-attachments/assets/8b19a015-2546-48db-884f-5e877f634cf9

