### PR TITLE
fix: adjust pagination styling on mobile

### DIFF
--- a/TCSA.V2026/Components/Pages/Dashboard/Activity.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Activity.razor
@@ -1,4 +1,4 @@
-﻿@page "/dashboard/activity"
+@page "/dashboard/activity"
 @using Microsoft.AspNetCore.Authorization
 @using System.Security.Claims
 @using System.ComponentModel.DataAnnotations
@@ -42,7 +42,13 @@
         {
             if (Pages > 1)
             {
-                <MudPagination Count="Pages" Selected="CurrentPage" SelectedChanged="OnPageChanged" />
+                <MudBreakpointProvider OnBreakpointChanged="BreakpointChanged">
+                    <MudPagination Count="Pages"
+                                   Selected="CurrentPage"
+                                   SelectedChanged="OnPageChanged"
+                                   BoundaryCount="_boundaryCount"
+                                   Size="_paginationSize" />
+                </MudBreakpointProvider>
             }
             <MudHidden Breakpoint="Breakpoint.LgAndUp">
                 @foreach(var a in UserActivity)
@@ -128,6 +134,8 @@
     private int Pages => (int)Math.Ceiling((double)TotalFilteredActivities / PagingConstants.ActivityPageSize);
     private string UserId = string.Empty;
     private TimeSpan LoadTime = TimeSpan.Zero;
+    private int _boundaryCount = 1;
+    private Size _paginationSize = Size.Medium;
 
     protected override async Task OnInitializedAsync()
     {
@@ -196,4 +204,17 @@
         CurrentPage = page;
     }
 
+    private void BreakpointChanged(Breakpoint breakpoint)
+    {
+        if (breakpoint < Breakpoint.Sm)
+        {
+            _paginationSize = Size.Small;
+            _boundaryCount = 1;
+        }
+        else
+        {
+            _paginationSize = Size.Medium;
+            _boundaryCount = 2;
+        }
+    }
 }

--- a/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
@@ -1,4 +1,4 @@
-﻿@page "/dashboard/challenges"
+@page "/dashboard/challenges"
 @using Microsoft.AspNetCore.Authorization
 @using System.Security.Claims
 @using TCSA.V2026.Data.Models
@@ -102,7 +102,15 @@
                 }
             </MudStack>
             @if (Pages > 1) {
-                <MudPagination Class="mt-3 justify-center" Style="width: 100%;" Count="Pages" Selected="CurrentPage" SelectedChanged="OnPageChanged" />
+                <MudBreakpointProvider OnBreakpointChanged="BreakpointChanged">
+                    <MudPagination Class="mt-3 justify-center"
+                                   Style="width: 100%;"
+                                   Count="Pages"
+                                   Selected="CurrentPage"
+                                   SelectedChanged="OnPageChanged"
+                                   BoundaryCount="_boundaryCount"
+                                   Size="_paginationSize" />
+                </MudBreakpointProvider>
             }
         }
     }
@@ -160,6 +168,8 @@
     private bool IsLoading = true;
     private string UserId = string.Empty;
     private TimeSpan LoadTime = TimeSpan.Zero;
+    private int _boundaryCount = 1;
+    private Size _paginationSize = Size.Medium;
 
     protected override async Task OnInitializedAsync()
     {
@@ -206,5 +216,19 @@
     private void OnPageChanged(int page)
     {
         CurrentPage = page;
+    }
+
+    private void BreakpointChanged(Breakpoint breakpoint)
+    {
+        if (breakpoint < Breakpoint.Sm)
+        {
+            _paginationSize = Size.Small;
+            _boundaryCount = 1;
+        }
+        else
+        {
+            _paginationSize = Size.Medium;
+            _boundaryCount = 2;
+        }
     }
 }

--- a/TCSA.V2026/Components/Pages/Dashboard/Leaderboard.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Leaderboard.razor
@@ -1,4 +1,4 @@
-﻿@page "/dashboard/leaderboard"
+@page "/dashboard/leaderboard"
 @using Microsoft.AspNetCore.Authorization
 
 @using System.Security.Claims;
@@ -37,7 +37,14 @@
             if (!IsReviews)
             {
                 if (Pages > 1) {
-                <MudPagination SelectedChanged="LoadPagination" Count="Pages" Selected="CurrentPage" />
+                    <MudBreakpointProvider OnBreakpointChanged="BreakpointChanged">
+                        <MudPagination
+                            SelectedChanged="LoadPagination"
+                            Count="Pages"
+                            Selected="CurrentPage"
+                            BoundaryCount="_boundaryCount"
+                            Size="_paginationSize" />
+                    </MudBreakpointProvider>
                 }
                 <MudDataGrid Class="mt-2" Dense="true" Items="@Users" Breakpoint="Breakpoint.None">
                     <Columns>
@@ -131,6 +138,8 @@
     private bool IsReviews = false;
     private string UserId = string.Empty;
     private TimeSpan LoadTime = TimeSpan.Zero;
+    private int _boundaryCount = 1;
+    private Size _paginationSize = Size.Medium;
 
     protected override async Task OnInitializedAsync()
     {
@@ -202,4 +211,18 @@
         string classNames = "pa-2 pa-md-3";
         return user.Id == UserId ? $"{classNames} mud-theme-primary" : classNames;
     };
+
+    private void BreakpointChanged(Breakpoint breakpoint)
+    {
+        if (breakpoint < Breakpoint.Sm)
+        {
+            _paginationSize = Size.Small;
+            _boundaryCount = 1;
+        }
+        else
+        {
+            _paginationSize = Size.Medium;
+            _boundaryCount = 2;
+        }
+    }
 }


### PR DESCRIPTION
#### Summary
The changes implement a `MudBreakpointProvider` to manage responsive pagination in the `Activity.razor`, `Challenges.razor`, and `Leaderboard.razor` files. This allows for dynamic adjustment of pagination properties based on the current breakpoint.

#### Changes
- **Activity.razor**: Added `MudBreakpointProvider` and updated pagination to include `BoundaryCount` and `Size`.
- **Challenges.razor**: Introduced `MudBreakpointProvider` for pagination and added new fields for managing pagination properties.
- **Leaderboard.razor**: Implemented `MudBreakpointProvider` for pagination and added logic to adjust pagination size and boundary count.
