### PR TITLE
fix: allow activity table text to wrap

### DIFF
--- a/TCSA.V2026/Components/Pages/Dashboard/Activity.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Activity.razor
@@ -86,7 +86,7 @@
                         </TemplateColumn>
                         <TemplateColumn>
                             <CellTemplate>
-                                <MudText Style="white-space:nowrap">
+                                <MudText>
                                     @((MarkupString)context.Item.Description)
                                 </MudText>
                             </CellTemplate>


### PR DESCRIPTION
#### Summary
This pull request fixes an issue where long text in the activity table was forced onto a single line, requiring horizontal scrolling to view the XP and total XP columns.

#### Changes
- Removed `white-space:nowrap` style