### PR TITLE
feat: enhance mobile responsiveness on ArticlePage

### DIFF
--- a/TCSA.V2026/Components/Pages/ArticlePage.razor
+++ b/TCSA.V2026/Components/Pages/ArticlePage.razor
@@ -14,9 +14,7 @@
 
 <MudContainer MaxWidth="MaxWidth.Large">
     <MudPaper Class="jumbotron d-flex align-center justify-center mt-3" Style=@GetBanner()>
-        <div class="jumbotron-overlay">
-            <h1 class="mud-typography-h3 text-white text-center">@Article.Title</h1>
-        </div>
+        <h1 class="mud-typography-h3 text-white mud-typography-align-center py-4 px-4 px-md-10">@Article.Title</h1>
     </MudPaper>
     @if (IsLoading)
     {
@@ -29,8 +27,8 @@
     }
 
     <MudGrid Class="mt-1">
-        <MudItem>
-            <MudPaper Class="d-flex flex-column mud-width-full py-1 pb-10 px-10">
+        <MudItem xs="12">
+            <MudPaper Class="d-flex flex-column mud-width-full py-1 pb-10 px-4 px-md-10">
                 @foreach (var block in Article.Blocks)
                 {
                     if (!string.IsNullOrWhiteSpace(block.Title))
@@ -127,7 +125,7 @@
     private string GetBanner()
     {
         var banner = string.IsNullOrEmpty(Article.BannerUrl) ? "article-banner.jpg" : Article.BannerUrl;
-        return $"position: relative; height: 250px; background-image: url('/img/banners/{banner}'); background-size: cover; background-position: center;";
+        return $"min-height: 250px; background-image: url('/img/banners/{banner}'); background-size: cover; background-position: center;";
     }
 
     private string GetImage(Paragraph paragraph) => $"img/{paragraph.PictureUrl}";


### PR DESCRIPTION
#### Summary
This pull request enhances mobile responsiveness on article pages.

#### Changes
- Updated `<h1>` element with additional padding classes for better alignment.
- Specified `xs="12"` for `<MudItem>` to ensure full width on extra-small screens.
- Adjusted padding on `<MudPaper>` from `px-10` to `px-4 px-md-10`.
- Removed `jumbotron-overlay` to make the banner flexible.
- Changed `GetBanner` method to use `min-height` instead of fixed height for the banner.

#### Preview
<img width="540" height="888" alt="image" src="https://github.com/user-attachments/assets/a9bfb3d5-51ae-4f96-9407-0bfd0f54519d" />
<img width="543" height="898" alt="image" src="https://github.com/user-attachments/assets/b42a377c-d119-4d13-850a-8ce22376a57f" />
<img width="1875" height="903" alt="image" src="https://github.com/user-attachments/assets/78e0c6d0-2c69-474f-8498-0a41c363b4e8" />

