### PR TITLE
Fix links matching more than once in the side menu.

### DIFF
--- a/TCSA.V2026/Components/Layout/NavMenu.razor
+++ b/TCSA.V2026/Components/Layout/NavMenu.razor
@@ -8,7 +8,7 @@
         <Authorized>
             <MudNavLink 
                 Href="Dashboard" 
-                Match="NavLinkMatch.Prefix" 
+                Match="NavLinkMatch.All" 
                 Icon="@Icons.Material.Filled.Dashboard"
                 IconColor="Color.Primary">
                 Dashboard


### PR DESCRIPTION
Changed NavLinkMatch to make sure the link match will never have more than one match.