### PR TITLE
fix: adjust padding to match with other pages layout

### DIFF
--- a/TCSA.V2026/Components/Pages/Dashboard/Leaderboard.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Leaderboard.razor
@@ -10,7 +10,7 @@
 @attribute [Authorize]
 
 <PageTitle>Leaderboard</PageTitle>
-<MudContainer Class="pa-0">
+<MudContainer>
     @if (User != null)
     {
         <DashboardToolBar User=@User></DashboardToolBar>

--- a/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
@@ -1,4 +1,4 @@
-﻿@page "/dashboard/reviews"
+@page "/dashboard/reviews"
 @using Microsoft.AspNetCore.Authorization
 @using System.Security.Claims
 @using TCSA.V2026.Data.Curriculum
@@ -12,7 +12,7 @@
 
 <PageTitle>Peer Reviews</PageTitle>
 
-<MudContainer Class="pa-0">
+<MudContainer>
 
     @if (User != null)
     {


### PR DESCRIPTION
#### Summary
This pull request updates the padding on the Leaderboard and Peer Review pages to match the layout styling used across the rest of the app

#### Changes
- `Leaderboard.razor` and `PeerReviews.razor`: Removed `Class="pa-0"` from `MudContainer`

#### Preview
<img width="1868" height="816" alt="image" src="https://github.com/user-attachments/assets/c2c01b93-9473-416c-a15c-3e12533b6386" />
<img width="1864" height="815" alt="image" src="https://github.com/user-attachments/assets/65664bc9-1013-4685-8bae-d6b10b589cac" />

