### PR TITLE
feat: add country field to registration

### DIFF
--- a/TCSA.V2026/Components/Account/Pages/Register.razor
+++ b/TCSA.V2026/Components/Account/Pages/Register.razor
@@ -305,6 +305,14 @@
 
     public async Task RegisterUser(EditContext editContext)
     {
+        if (string.IsNullOrEmpty(Input.Country) || !Countries.Contains(Input.Country))
+        {
+            var messages = new ValidationMessageStore(editContext);
+            messages.Add(() => Input.Country, "Please select a valid country.");
+            editContext.NotifyValidationStateChanged();
+            return;
+        }
+
         var user = CreateUser();
 
         await UserStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);


### PR DESCRIPTION
#### Summary
This pull request adds a custom country selector to the registration form and ensures the selected country is validated and saved during user registration. I had to create a custom selector because MudSelect uses JS interop, which doesn’t work with statically rendered pages in Blazor.

#### Changes
- Register.razor: Implements a custom country dropdown using HTML, CSS, and JavaScript.
- Register.razor: Adds a required Country property to the Input model and enforces server-side validation.
- Register.razor: Updates user registration logic to save the selected country to the user object.

#### Preview
https://www.loom.com/share/eddeb85d1cd04116b544021da1abd920
