### PR TITLE
Remove focus outline for programmatically focused elements

### DIFF
--- a/TCSA.V2026/wwwroot/css/site.css
+++ b/TCSA.V2026/wwwroot/css/site.css
@@ -135,6 +135,11 @@
     border: 0;
 }
 
+/* Remove the focus outline for elements focused programmatically by Blazor */
+[tabindex="-1"]:focus {
+    outline: none !important;
+}
+
 .external-email-wrap {
     width: 100% !important;
     max-width: 520px !important; /* increase if you want */


### PR DESCRIPTION
Fixes #314 

Added this to `TCSA.V2026/wwwroot/css/site.css` :
<img width="1186" height="154" alt="image" src="https://github.com/user-attachments/assets/634f95a7-4ae4-434c-a6f8-b24ad947b1c3" />

The issue was that when we use :
```C#
<FocusOnNavigate RouteData="routeData" Selector="h1" /> 
```
it temporarily injects `tabindex="-1"` to that `<h1>`

So this global CSS change just hides the rectangle (layout), without breaking the navigation behavior.

Waiting for your review! 😃 

Note that the issue was also happening in blog page, and sometimes in home page for the same reason.