### PR TITLE
test: update belt tests to check enum lists

### DIFF
--- a/TCSA.V2026.UnitTests/Helpers/BeltTests.cs
+++ b/TCSA.V2026.UnitTests/Helpers/BeltTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using TCSA.V2026.Data.Helpers;
@@ -528,21 +528,21 @@ public class BeltTests
     }
 
     [TestCaseSource(nameof(FullStackAreaTestCases))]
-    public void GetFullStackAreasCompletedReturnsExpectedCount(List<int> completedProjects, int expectedCount)
+    public void GetFullStackAreasCompletedReturnsExpectedAreas(List<int> completedProjects, List<Area> expectedAreas)
     {
         var result = RoadmapHelper.GetFullStackAreasCompleted(completedProjects);
-        Assert.That(result, Is.EqualTo(expectedCount));
+        Assert.That(result, Is.EquivalentTo(expectedAreas));
     }
 
     private static IEnumerable<TestCaseData> FullStackAreaTestCases()
     {
-        yield return new TestCaseData(AspNetRequirements.ToList(), 1).SetName("MVC only");
-        yield return new TestCaseData(ReactRequirements.ToList(), 1).SetName("React only");
-        yield return new TestCaseData(AngularRequirements.ToList(), 1).SetName("Angular only");
-        yield return new TestCaseData(BlazorRequirements.ToList(), 1).SetName("Blazor only");
-        yield return new TestCaseData(MauiRequirements.ToList(), 1).SetName("MAUI only");
+        yield return new TestCaseData(AspNetRequirements.ToList(), new List<Area> { Area.MVC }).SetName("MVC only");
+        yield return new TestCaseData(ReactRequirements.ToList(), new List<Area> { Area.React }).SetName("React only");
+        yield return new TestCaseData(AngularRequirements.ToList(), new List<Area> { Area.Angular }).SetName("Angular only");
+        yield return new TestCaseData(BlazorRequirements.ToList(), new List<Area> { Area.Blazor }).SetName("Blazor only");
+        yield return new TestCaseData(MauiRequirements.ToList(), new List<Area> { Area.MAUI }).SetName("MAUI only");
         yield return new TestCaseData(
-            new List<int>([.. AspNetRequirements, .. ReactRequirements]), 2).SetName("MVC and React");
-        yield return new TestCaseData(new List<int>(), 0).SetName("None completed");
+            new List<int>([.. AspNetRequirements, .. ReactRequirements]), new List<Area> { Area.MVC, Area.React }).SetName("MVC and React");
+        yield return new TestCaseData(new List<int>(), new List<Area>()).SetName("None completed");
     }
 }


### PR DESCRIPTION
#### Summary
Updated unit tests to assert on actual completed areas instead of counts.

#### Changes
- BeltTests.cs: Renamed the test method to GetFullStackAreasCompletedReturnsExpectedAreas, updated assertions to compare lists of Area enums and revised test case data to provide expected areas instead of counts.

