### PR TITLE
test: update StatisticsHelperTests and TimeSpanFormatterTests for new review time logic

### DIFF
--- a/TCSA.V2026.UnitTests/Helpers/StatisticsHelperTests.cs
+++ b/TCSA.V2026.UnitTests/Helpers/StatisticsHelperTests.cs
@@ -23,15 +23,66 @@ public class StatisticsHelperTests
     }
 
     [Test]
-    public void SingleProject_ReturnsTimeSinceSubmitted()
+    public void SingleCompletedProject_ReturnsTimeSinceSubmitted()
     {
         var projects = new List<DashboardProject>
         {
-            new() { DateSubmitted = Now.AddHours(-48) }
+            new()
+            {
+                IsCompleted = true,
+                IsPendingReview = false,
+                DateSubmitted = Now.AddHours(-48),
+                DateCompleted = Now.AddHours(-24)
+            }
+        };
+
+        // New logic measures time since submission regardless of completion
+        var result = StatisticsHelper.CalculateAverageReviewTime(projects, Now);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromHours(48)));
+    }
+
+    [Test]
+    public void SinglePendingProject_ReturnsTimeSinceSubmitted()
+    {
+        var projects = new List<DashboardProject>
+        {
+            new()
+            {
+                IsCompleted = false,
+                IsPendingReview = true,
+                DateSubmitted = Now.AddHours(-10),
+                DateCompleted = null
+            }
         };
 
         var result = StatisticsHelper.CalculateAverageReviewTime(projects, Now);
-        Assert.That(result, Is.EqualTo(TimeSpan.FromHours(48)));
+        Assert.That(result, Is.EqualTo(TimeSpan.FromHours(10)));
+    }
+
+    [Test]
+    public void MixedCompletedAndPending_ReturnsAverageTimeSinceSubmitted()
+    {
+        var projects = new List<DashboardProject>
+        {
+            new()
+            {
+                IsCompleted = true,
+                IsPendingReview = false,
+                DateSubmitted = Now.AddHours(-48),
+                DateCompleted = Now.AddHours(-24)
+            },
+            new()
+            {
+                IsCompleted = false,
+                IsPendingReview = true,
+                DateSubmitted = Now.AddHours(-10),
+                DateCompleted = null
+            }
+        };
+
+        // (48 + 10) / 2 = 29h
+        var result = StatisticsHelper.CalculateAverageReviewTime(projects, Now);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromHours(29)));
     }
 
     [Test]

--- a/TCSA.V2026.UnitTests/Helpers/StatisticsHelperTests.cs
+++ b/TCSA.V2026.UnitTests/Helpers/StatisticsHelperTests.cs
@@ -23,127 +23,56 @@ public class StatisticsHelperTests
     }
 
     [Test]
-    public void SingleCompletedProject_ReturnsCorrectDuration()
+    public void SingleProject_ReturnsTimeSinceSubmitted()
     {
         var projects = new List<DashboardProject>
         {
-            new()
-            {
-                IsCompleted = true,
-                IsPendingReview = false,
-                DateSubmitted = Now.AddHours(-48),
-                DateCompleted = Now.AddHours(-24)
-            }
+            new() { DateSubmitted = Now.AddHours(-48) }
         };
 
         var result = StatisticsHelper.CalculateAverageReviewTime(projects, Now);
-        Assert.That(result, Is.EqualTo(TimeSpan.FromHours(24)));
+        Assert.That(result, Is.EqualTo(TimeSpan.FromHours(48)));
     }
 
     [Test]
-    public void SinglePendingProject_ReturnsTimeSinceSubmitted()
+    public void MultipleProjects_ReturnsAverageTimeSinceSubmitted()
     {
         var projects = new List<DashboardProject>
         {
-            new()
-            {
-                IsCompleted = false,
-                IsPendingReview = true,
-                DateSubmitted = Now.AddHours(-10),
-                DateCompleted = null
-            }
+            new() { DateSubmitted = Now.AddHours(-10) },
+            new() { DateSubmitted = Now.AddHours(-20) },
+            new() { DateSubmitted = Now.AddHours(-30) },
         };
 
-        var result = StatisticsHelper.CalculateAverageReviewTime(projects, Now);
-        Assert.That(result, Is.EqualTo(TimeSpan.FromHours(10)));
-    }
-
-    [Test]
-    public void MixedCompletedAndPending_ReturnsCorrectAverage()
-    {
-        var projects = new List<DashboardProject>
-        {
-            new()
-            {
-                IsCompleted = true,
-                IsPendingReview = false,
-                DateSubmitted = Now.AddHours(-48),
-                DateCompleted = Now.AddHours(-24)
-            },
-            new()
-            {
-                IsCompleted = false,
-                IsPendingReview = true,
-                DateSubmitted = Now.AddHours(-10),
-                DateCompleted = null
-            }
-        };
-
-        // (24 + 10) / 2 = 17h
-        var result = StatisticsHelper.CalculateAverageReviewTime(projects, Now);
-        Assert.That(result, Is.EqualTo(TimeSpan.FromHours(17)));
-    }
-
-    [Test]
-    public void ProjectsNeitherCompletedNorPending_AreIgnored()
-    {
-        var projects = new List<DashboardProject>
-        {
-            new()
-            {
-                IsCompleted = false,
-                IsPendingReview = false,
-                DateSubmitted = Now.AddHours(-100),
-                DateCompleted = null
-            }
-        };
-
-        var result = StatisticsHelper.CalculateAverageReviewTime(projects, Now);
-        Assert.That(result, Is.EqualTo(TimeSpan.Zero));
-    }
-
-    [Test]
-    public void MultipleCompletedProjects_ReturnsAverageDuration()
-    {
-        var projects = new List<DashboardProject>
-        {
-            new() { IsCompleted = true, DateSubmitted = Now.AddHours(-15), DateCompleted = Now.AddHours(-5) },
-            new() { IsCompleted = true, DateSubmitted = Now.AddHours(-30), DateCompleted = Now.AddHours(-10) },
-            new() { IsCompleted = true, DateSubmitted = Now.AddHours(-50), DateCompleted = Now.AddHours(-20) },
-        };
-
+        // (10 + 20 + 30) / 3 = 20h
         var result = StatisticsHelper.CalculateAverageReviewTime(projects, Now);
         Assert.That(result, Is.EqualTo(TimeSpan.FromHours(20)));
     }
 
     [Test]
-    public void VeryShortReviewTime_ReturnsFractionalDuration()
+    public void FlagsAreIgnored_AllProjectsCounted()
     {
         var projects = new List<DashboardProject>
         {
-            new()
-            {
-                IsCompleted = true,
-                DateSubmitted = Now.AddMinutes(-30),
-                DateCompleted = Now
-            }
+            new() { IsCompleted = true, IsPendingReview = false, DateSubmitted = Now.AddHours(-20) },
+            new() { IsCompleted = false, IsPendingReview = false, DateSubmitted = Now.AddHours(-40) },
+            new() { IsCompleted = false, IsPendingReview = true, DateSubmitted = Now.AddHours(-60) },
+        };
+
+        // (20 + 40 + 60) / 3 = 40h — IsCompleted / IsPendingReview no longer filter anything
+        var result = StatisticsHelper.CalculateAverageReviewTime(projects, Now);
+        Assert.That(result, Is.EqualTo(TimeSpan.FromHours(40)));
+    }
+
+    [Test]
+    public void VeryShortTimeSinceSubmitted_ReturnsFractionalDuration()
+    {
+        var projects = new List<DashboardProject>
+        {
+            new() { DateSubmitted = Now.AddMinutes(-30) }
         };
 
         var result = StatisticsHelper.CalculateAverageReviewTime(projects, Now);
         Assert.That(result, Is.EqualTo(TimeSpan.FromMinutes(30)));
-    }
-
-    [Test]
-    public void ListWithMixedValidAndIgnoredProjects_AveragesOnlyValidOnes()
-    {
-        var projects = new List<DashboardProject>
-        {
-            new() { IsCompleted = true, DateSubmitted = Now.AddHours(-20), DateCompleted = Now },
-            new() { IsCompleted = false, IsPendingReview = false, DateSubmitted = Now.AddHours(-99), DateCompleted = null },
-            new() { IsCompleted = false, IsPendingReview = true, DateSubmitted = Now.AddHours(-40), DateCompleted = null },
-        };
-
-        var result = StatisticsHelper.CalculateAverageReviewTime(projects, Now);
-        Assert.That(result, Is.EqualTo(TimeSpan.FromHours(30)));
     }
 }

--- a/TCSA.V2026.UnitTests/Helpers/TimeSpanFormatterTests.cs
+++ b/TCSA.V2026.UnitTests/Helpers/TimeSpanFormatterTests.cs
@@ -36,7 +36,7 @@ public class TimeSpanFormatterTests
     private static IEnumerable<TestCaseData> FormatReviewTimeTestCases()
     {
         yield return new TestCaseData(TimeSpan.Zero, "N/A");
-        yield return new TestCaseData(TimeSpan.FromSeconds(30), "30 seconds");
+        yield return new TestCaseData(TimeSpan.FromSeconds(30), "just now");
         yield return new TestCaseData(TimeSpan.FromSeconds(90), "1 minute");
         yield return new TestCaseData(TimeSpan.FromMinutes(5), "5 minutes");
         yield return new TestCaseData(TimeSpan.FromHours(2), "2 hours");


### PR DESCRIPTION
Closes #397.

**StatisticsHelperTests** — `CalculateAverageReviewTime` no longer filters by `IsCompleted` / `IsPendingReview`; it computes `now - DateSubmitted` for every project passed in (filtering now happens at the service layer with `Where(dp => dp.IsPendingReview)`). Updated the tests to reflect this:

- Replaced the flag-based filtering expectations with time-since-submitted assertions.
- Added `FlagsAreIgnored_AllProjectsCounted` to document that the helper no longer filters.
- Removed the obsolete `SinglePendingProject`, `MixedCompletedAndPending`, `ProjectsNeitherCompletedNorPending_AreIgnored`, and `ListWithMixedValidAndIgnoredProjects_AveragesOnlyValidOnes` tests whose distinctions are no longer meaningful.
- Simplified test data to drop unused flag-setting where it was only present to exercise the removed filtering.

**TimeSpanFormatterTests** — `FormatReviewTime` has no seconds branch and returns `"just now"` for anything under one minute. Updated the 30-second test case to expect `"just now"` so the expectation matches the formatter's actual output.