### PR TITLE
refactor: optimize PeerReview query to eliminate blocking calls and redundant db round trips

### DIFF
--- a/TCSA.V2026/Helpers/PeerReviewHelpers.cs
+++ b/TCSA.V2026/Helpers/PeerReviewHelpers.cs
@@ -1,4 +1,4 @@
-﻿using TCSA.V2026.Data.Curriculum;
+using TCSA.V2026.Data.Curriculum;
 using TCSA.V2026.Data.DTOs;
 using TCSA.V2026.Data.Enums;
 using TCSA.V2026.Data.Models;
@@ -30,7 +30,7 @@ public static class PeerReviewHelpers
         if (level > Level.Red)
         {
             beginnerProjects.AddRange(new List<int>
-            {   
+            {
                 (int) ArticleName.Ecommerce,
                 (int) ArticleName.ExcelReader,
                 (int) ArticleName.SportsResults,
@@ -51,30 +51,30 @@ public static class PeerReviewHelpers
 
         if (completedAreas == null) { return result; }
 
-        if (completedAreas.Contains(Area.Angular)) 
-        { 
-            result.AddRange(RoadmapHelper.angularProjects.Where(p => p != (int)ArticleName.Quizgame)); 
-        };
-
-        if (completedAreas.Contains(Area.React)) 
-        { 
-            result.AddRange(RoadmapHelper.reactProjects.Where(p => p != (int)ArticleName.FriendsManager)); 
+        if (completedAreas.Contains(Area.Angular))
+        {
+            result.AddRange(RoadmapHelper.angularProjects.Where(p => p != (int)ArticleName.Quizgame));
         }
 
-        if (completedAreas.Contains(Area.MVC)) 
-        { 
-            result.AddRange(RoadmapHelper.mvcProjects.Where(p => p != (int)ArticleName.Budget)); 
+        if (completedAreas.Contains(Area.React))
+        {
+            result.AddRange(RoadmapHelper.reactProjects.Where(p => p != (int)ArticleName.FriendsManager));
         }
 
-        if (completedAreas.Contains(Area.Blazor)) 
-        { 
-            result.AddRange(RoadmapHelper.blazorProjects.Where(p => p != (int)ArticleName.SportsStatistics)); 
+        if (completedAreas.Contains(Area.MVC))
+        {
+            result.AddRange(RoadmapHelper.mvcProjects.Where(p => p != (int)ArticleName.Budget));
+        }
+
+        if (completedAreas.Contains(Area.Blazor))
+        {
+            result.AddRange(RoadmapHelper.blazorProjects.Where(p => p != (int)ArticleName.SportsStatistics));
         }
 
         return result;
     }
 
-    public static List<PeerReviewDisplay> MapPeerReviewDisplays(List<DashboardProject> dashboardProjects, List<UserReview> reviews)
+    public static List<PeerReviewDisplay> MapPeerReviewDisplays(List<DashboardProject> dashboardProjects, HashSet<int> reviewedDashboardProjectIds)
     {
         var result = new List<PeerReviewDisplay>();
         var projects = ProjectHelper.GetProjects();
@@ -85,7 +85,7 @@ public static class PeerReviewHelpers
             result.Add(new PeerReviewDisplay
             {
                 DashboardProjectId = dp.Id,
-                IsAssigned = reviews.Any(x => x.DashboardProjectId == dp.Id),
+                IsAssigned = reviewedDashboardProjectIds.Contains(dp.Id),
                 Title = project.Title,
                 IconUrl = project.IconUrl,
                 ProjectId = dp.ProjectId,
@@ -102,13 +102,13 @@ public static class PeerReviewHelpers
 
     public static string GetRevieweeName(ApplicationUser user)
     {
-        var displayName = 
-            string.IsNullOrEmpty(user.DisplayName) 
-            ? user.FirstName + " " + user.LastName 
+        var displayName =
+            string.IsNullOrEmpty(user.DisplayName)
+            ? user.FirstName + " " + user.LastName
             : user.DisplayName;
 
         var githubUsername = string.IsNullOrEmpty(user.GithubUsername) ? "" : user.GithubUsername;
 
-        return displayName == " " ? githubUsername : displayName;   
+        return displayName == " " ? githubUsername : displayName;
     }
 }

--- a/TCSA.V2026/Services/PeerReviewService.cs
+++ b/TCSA.V2026/Services/PeerReviewService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using System.Data;
 using TCSA.V2026.Data;
 using TCSA.V2026.Data.Curriculum;
@@ -39,7 +39,7 @@ public class PeerReviewService(IDbContextFactory<ApplicationDbContext> _factory)
             }
 
             return result;
-        } 
+        }
         catch (Exception ex)
         {
             result.Message = ex.Message;
@@ -104,7 +104,7 @@ public class PeerReviewService(IDbContextFactory<ApplicationDbContext> _factory)
             "https://github.com/the-csharp-academy/CodeReviews",
             "https://github.com/TheCSharpAcademy/CodeReviews"
         };
-   
+
         try
         {
             using (var context = _factory.CreateDbContext())
@@ -119,28 +119,26 @@ public class PeerReviewService(IDbContextFactory<ApplicationDbContext> _factory)
                 {
                     return new List<PeerReviewDisplay> { };
                 }
-             
-                List<int> eligibleProjectIds = 
+
+                List<int> eligibleProjectIds =
                     PeerReviewHelpers.DetermineReviewableProjectIds(user.Level, user.DashboardProjects.Select(dp => dp.ProjectId));
 
-                var reviewProjects = context.UserReviews
+                var assignedProjectIds = context.UserReviews
                     .Where(x => x.AppUserId != user.Id)
-                    .Select(x => x.DashboardProjectId)
-                    .ToList();
+                    .Select(x => x.DashboardProjectId);
 
                 var projects = await context.DashboardProjects
-                .AsSplitQuery()
-                .Include(x => x.AppUser)
-                .Where(x => x.IsPendingReview
-                   && eligibleProjectIds.Contains(x.ProjectId)
-                   && !reviewProjects.Contains(x.Id)
-                   && (x.GithubUrl.StartsWith(validUrls[0]) || x.GithubUrl.StartsWith(validUrls[1])))
-                .OrderBy(x => x.DateSubmitted)
-                .ToListAsync();
+                    .AsNoTracking()
+                    .Include(x => x.AppUser)
+                    .Where(x => x.IsPendingReview
+                        && eligibleProjectIds.Contains(x.ProjectId)
+                        && !assignedProjectIds.Contains(x.Id)
+                        && (x.GithubUrl.StartsWith(validUrls[0]) || x.GithubUrl.StartsWith(validUrls[1])))
+                    .OrderBy(x => x.DateSubmitted)
+                    .ToListAsync();
 
-                var result = PeerReviewHelpers.MapPeerReviewDisplays(projects, user.CodeReviewProjects);
-
-                return result;
+                var reviewedIds = new HashSet<int>(user.CodeReviewProjects.Select(x => x.DashboardProjectId));
+                return PeerReviewHelpers.MapPeerReviewDisplays(projects, reviewedIds);
             }
         }
         catch (Exception ex)
@@ -228,9 +226,9 @@ public class PeerReviewService(IDbContextFactory<ApplicationDbContext> _factory)
                     }
                 );
 
-                if (reviewer != null 
-                    && reviewedProjects != null 
-                    && reviewer.ReviewExperiencePoints == 0 
+                if (reviewer != null
+                    && reviewedProjects != null
+                    && reviewer.ReviewExperiencePoints == 0
                     && reviewedProjects.Count > 0)
                 {
                     //This has to be retroactive, so if some user has reviews but no points, it will calculate them first.


### PR DESCRIPTION
## Description

Optimize peer review query flow and helper project lookup performance.

## Related Issue

Closes #408

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / configuration
- [ ] Other: <!-- describe -->

## Implementation Details

`PeerReviewService.cs`
- Reduced blocking patterns in peer review retrieval path and aligned with async EF usage.
- Improved filtering of reviewable projects by replacing reviewProjects query with an subquery so filtering is done entirely server-side.
- Filtering entirely on server-side also fixed the possible problem with hard limit of 2100 parameters in `IN (...)` clause. It additionaly reduced DB round trips.

`PeerReviewsHelpers.cs`
- Improved project assignment lookup in `MapPeerReviewDisplays` by avoiding `O(n)` lookups in the worst-case scenario and using a HashSet for `O(1)` lookups.

## Testing Performed

<!-- Describe how you tested this change. -->

- [x] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [x] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [x] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [ ] Added new tests covering the change
- [x] Manually verified in the browser

## Screenshots

<!-- If this PR affects the UI, include before/after screenshots or a screen recording. Remove this section if not applicable. -->

| Before | After |
|--------|-------|
|  <img width="1902" height="430" alt="image" src="https://github.com/user-attachments/assets/097318d8-4bda-46e3-8abe-f83fb99fb188" /> |     <img width="1919" height="376" alt="image" src="https://github.com/user-attachments/assets/5b81c30c-e7ea-4bb7-b2ce-65ab8764b567" /> |

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have read the related issue and my implementation matches the requirements
- [x] No sensitive data (credentials, secrets) committed
- [x] All new and existing tests pass

## Additional Context

<!-- Anything else reviewers should know: related PRs, migration notes, deployment considerations, etc. -->
