### PR TITLE
fix: prevent duplicate submission exception

### DIFF
--- a/TCSA.V2026.EndToEndTests/RegisterPageTests.cs
+++ b/TCSA.V2026.EndToEndTests/RegisterPageTests.cs
@@ -1,0 +1,29 @@
+namespace TCSA.V2026.EndToEndTests;
+
+[NonParallelizable]
+[TestFixture]
+public class RegisterPageTests : EndToEndTestsBase
+{
+    [Test]
+    public async Task Register_DoubleSubmit_ShouldStillRedirectToHome()
+    {
+        var email = $"e2e-register-{Guid.NewGuid():N}@example.com";
+
+        await Page.GotoAsync($"{BaseUrl}/Account/Register");
+
+        await Page.GetByLabel("DisplayName").FillAsync("E2E User");
+        await Page.GetByLabel("Email").FillAsync(email);
+        await Page.GetByLabel("Password", new() { Exact = true }).FillAsync("Password123!");
+        await Page.GetByLabel("Confirm Password", new() { Exact = true }).FillAsync("Password123!");
+
+        await Page.Locator("#country-select .custom-select-trigger").ClickAsync();
+        await Page.Locator("#country-options .custom-select-option").First.ClickAsync();
+
+        var registerButton = Page.Locator("form [type='submit']").First;
+
+        await registerButton.DblClickAsync();
+
+        await Expect(Page).ToHaveURLAsync($"{BaseUrl}/");
+        await Expect(Page.GetByText("An account with this email already exists.")).Not.ToBeVisibleAsync();
+    }
+}

--- a/TCSA.V2026/Components/Account/Pages/Register.razor
+++ b/TCSA.V2026/Components/Account/Pages/Register.razor
@@ -5,6 +5,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
+@using Microsoft.EntityFrameworkCore
 @using TCSA.V2026.Data
 @using TCSA.V2026.Data.Enums
 @using TCSA.V2026.Data.Models
@@ -306,6 +307,8 @@
 
     public async Task RegisterUser(EditContext editContext)
     {
+        identityErrors = null;
+
         if (string.IsNullOrEmpty(Input.Country) || !Countries.Contains(Input.Country))
         {
             var messages = new ValidationMessageStore(editContext);
@@ -327,10 +330,46 @@
         user.Level = Level.White;
         user.CreatedDate = DateTime.UtcNow;
 
-        var result = await UserManager.CreateAsync(user, Input.Password);
+        IdentityResult result;
+        try
+        {
+            result = await UserManager.CreateAsync(user, Input.Password);
+        }
+        catch (DbUpdateException ex)
+        {
+            Logger.LogWarning(ex, "Registration create failed. Attempting idempotent sign-in.");
+            var signInResult = await SignInManager.PasswordSignInAsync(Input.Email, Input.Password, isPersistent: true, lockoutOnFailure: true);
+
+            if (signInResult.Succeeded)
+            {
+                RedirectManager.RedirectTo(ReturnUrl);
+                return;
+            }
+
+            identityErrors =
+            [
+                new IdentityError { Description = "We couldn't complete registration. Please check your details and try again." }
+            ];
+            return;
+        }
 
         if (!result.Succeeded)
         {
+            if (result.Errors.Any(e => e.Code is "DuplicateEmail" or "DuplicateUserName"))
+            {
+                var signInResult = await SignInManager.PasswordSignInAsync(
+                    Input.Email,
+                    Input.Password,
+                    isPersistent: true,
+                    lockoutOnFailure: true);
+
+                if (signInResult.Succeeded)
+                {
+                    RedirectManager.RedirectTo(ReturnUrl);
+                    return;
+                }
+            }
+
             identityErrors = result.Errors;
             return;
         }


### PR DESCRIPTION
## Description

Prevent duplicate registration submissions on the static `Register` page by improving duplicate-submit handling in the registration flow.  This change prevents duplicate-submit exceptions from surfacing to users and avoids exposing internal error details in the UI.

## Related Issue

Closes #411

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / configuration
- [ ] Other: <!-- describe -->

## Implementation Details

- Updated registration flow in `Register.razor` to handle rapid repeated submits safely.
- Improved duplicate-registration fallback so successful first submit still results in sign-in/redirect behavior.
- Replaced user-visible duplicate-account error leakage in this flow with safer generic handling.
- Added end-to-end regression coverage in `RegisterPageTests.cs`

## Testing Performed

<!-- Describe how you tested this change. -->

- [x] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [x] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [x] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [x] Added new tests covering the change
- [x] Manually verified in the browser

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have read the related issue and my implementation matches the requirements
- [x] No sensitive data (credentials, secrets) committed
- [x] All new and existing tests pass

## Additional Context

<!-- Anything else reviewers should know: related PRs, migration notes, deployment considerations, etc. -->
