### PR TITLE
fix: github approval duplicating history

### DIFF
--- a/TCSA.2026.IntegrationTests/GithubServiceTests.cs
+++ b/TCSA.2026.IntegrationTests/GithubServiceTests.cs
@@ -213,4 +213,73 @@ public class GithubServiceTests : IntegrationTestsBase
         Assert.That(reviewer.ExperiencePoints.Equals(110));
         Assert.That(reviewee.ExperiencePoints.Equals(10));
     }
+
+    [Test]
+    public async Task MarkAsCompleted_WhenDuplicateRequestsForSameProject_AwardsPointsOnlyOnce()
+    {
+        const int dashboardProjectId = 150;
+        const int prNumber = 950;
+
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = dashboardProjectId,
+                AppUserId = "user1",
+                ProjectId = (int)ArticleName.Calculator,
+                IsArchived = false,
+                IsPendingNotification = false,
+                IsPendingReview = true,
+                IsCompleted = false,
+                DateSubmitted = DateTimeOffset.UtcNow.AddDays(-1),
+                GithubUrl = $"test_pull_request/{prNumber}"
+            });
+
+            seedContext.UserReviews.Add(new UserReview
+            {
+                Id = 150,
+                DashboardProjectId = dashboardProjectId,
+                AppUserId = "user2"
+            });
+
+            await seedContext.SaveChangesAsync();
+        }
+
+        var dto = new PullRequestReviewDto
+        {
+            Review = new Review { State = "approved" },
+            Repository = new Repository { Id = 573911382 },
+            PullRequest = new PullRequest { Number = prNumber }
+        };
+
+        var firstResult = await _service.MarkAsCompleted(dto);
+
+        var secondResult = await _service.MarkAsCompleted(dto);
+
+        using var assertContext = DbContextFactory.CreateDbContext();
+
+        var project = assertContext.DashboardProjects.First(p => p.Id == dashboardProjectId);
+        var reviewee = assertContext.Users.First(u => u.Id == "user1");
+        var reviewer = assertContext.Users.First(u => u.Id == "user2");
+
+        var projectCompletedActivities = assertContext.UserActivity.Count(a =>
+            a.AppUserId == "user1"
+            && a.ProjectId == (int)ArticleName.Calculator
+            && a.ActivityType == ActivityType.ProjectCompleted);
+
+        var codeReviewCompletedActivities = assertContext.UserActivity.Count(a =>
+            a.AppUserId == "user2"
+            && a.ProjectId == (int)ArticleName.Calculator
+            && a.ActivityType == ActivityType.CodeReviewCompleted);
+
+        Assert.That(firstResult.Status, Is.EqualTo(ResponseStatus.Success));
+        Assert.That(secondResult.Status, Is.EqualTo(ResponseStatus.Success));
+        Assert.That(project.IsCompleted, Is.True);
+
+        Assert.That(reviewee.ExperiencePoints, Is.EqualTo(10), "Reviewee should get points once.");
+        Assert.That(reviewer.ExperiencePoints, Is.EqualTo(110), "Reviewer should get points once.");
+
+        Assert.That(projectCompletedActivities, Is.EqualTo(1));
+        Assert.That(codeReviewCompletedActivities, Is.EqualTo(1));
+    }
 }

--- a/TCSA.V2026/Services/GithubService.cs
+++ b/TCSA.V2026/Services/GithubService.cs
@@ -11,13 +11,22 @@ namespace TCSA.V2026.Services;
 public interface IGithubService
 {
     Task<BaseResponse> MarkAsCompleted(PullRequestReviewDto? pullRequestReviewDto);
-    Task<BaseResponse> ProcessPullRequest(PullRequestDto pullRequestDto);
+    Task<BaseResponse> ProcessPullRequest(PullRequestDto? pullRequestDto);
 }
 
 public class GithubService(IDbContextFactory<ApplicationDbContext> _factory) : IGithubService
 {
-    public async Task<BaseResponse> ProcessPullRequest(PullRequestDto pullRequestDto)
+    public async Task<BaseResponse> ProcessPullRequest(PullRequestDto? pullRequestDto)
     {
+        if (pullRequestDto is null)
+        {
+            return new BaseResponse
+            {
+                Status = ResponseStatus.Fail,
+                Message = "Invalid pull request payload."
+            };
+        }
+
         if (!pullRequestDto.Action.Equals("opened"))
         {
             return new BaseResponse
@@ -40,7 +49,6 @@ public class GithubService(IDbContextFactory<ApplicationDbContext> _factory) : I
 
         using (var context = _factory.CreateDbContext())
         {
-            var fuckingName = "TheCSharpAcademy";
             var user = await context.AspNetUsers
                 .Include(u => u.DashboardProjects)
                 .FirstOrDefaultAsync(u => u.GithubUsername.Trim().ToLower() == pullRequestDto.PullRequest.User.Login.Trim().ToLower());
@@ -96,7 +104,7 @@ public class GithubService(IDbContextFactory<ApplicationDbContext> _factory) : I
         if (pullRequestReviewDto is null)
         {
             return new BaseResponse
-    {
+            {
                 Status = ResponseStatus.Fail,
                 Message = "Invalid pull request review payload."
             };

--- a/TCSA.V2026/Services/GithubService.cs
+++ b/TCSA.V2026/Services/GithubService.cs
@@ -10,7 +10,7 @@ namespace TCSA.V2026.Services;
 
 public interface IGithubService
 {
-    Task<BaseResponse> MarkAsCompleted(PullRequestReviewDto pullRequestReviewDto);
+    Task<BaseResponse> MarkAsCompleted(PullRequestReviewDto? pullRequestReviewDto);
     Task<BaseResponse> ProcessPullRequest(PullRequestDto pullRequestDto);
 }
 
@@ -91,8 +91,17 @@ public class GithubService(IDbContextFactory<ApplicationDbContext> _factory) : I
         };
     }
 
-    public async Task<BaseResponse> MarkAsCompleted(PullRequestReviewDto pullRequestReviewDto)
+    public async Task<BaseResponse> MarkAsCompleted(PullRequestReviewDto? pullRequestReviewDto)
     {
+        if (pullRequestReviewDto is null)
+        {
+            return new BaseResponse
+    {
+                Status = ResponseStatus.Fail,
+                Message = "Invalid pull request review payload."
+            };
+        }
+
         if (!pullRequestReviewDto.Review.State.Equals("approved"))
         {
             return new BaseResponse

--- a/TCSA.V2026/Services/GithubService.cs
+++ b/TCSA.V2026/Services/GithubService.cs
@@ -150,7 +150,7 @@ public class GithubService(IDbContextFactory<ApplicationDbContext> _factory) : I
                 var project = await context.DashboardProjects
                     .Include(p => p.AppUser)
                        .ThenInclude(u => u.UserActivity)
-                    .FirstOrDefaultAsync(p => p.ProjectId == projectId && p.GithubUrl.Contains(pullRequestReviewDto.PullRequest.Number.ToString()));
+                    .FirstOrDefaultAsync(p => p.ProjectId == projectId && p.GithubUrl.EndsWith($"/{pullRequestReviewDto.PullRequest.Number}"));
 
                 if (project == null)
                 {

--- a/TCSA.V2026/Services/GithubService.cs
+++ b/TCSA.V2026/Services/GithubService.cs
@@ -1,4 +1,3 @@
-﻿using Microsoft.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using TCSA.V2026.Data;
 using TCSA.V2026.Data.Curriculum;
@@ -144,6 +143,16 @@ public class GithubService(IDbContextFactory<ApplicationDbContext> _factory) : I
                         Message = "Project submission not found for this pull request."
                     };
                 }
+
+                if (project.IsCompleted)
+                {
+                    return new BaseResponse
+                    {
+                        Status = ResponseStatus.Success,
+                        Message = "Pull request was already processed as completed."
+                    };
+                }
+
                 project.IsPendingNotification = true;
                 project.IsPendingReview = false;
                 project.IsCompleted = true;

--- a/TCSA.V2026/Services/GithubService.cs
+++ b/TCSA.V2026/Services/GithubService.cs
@@ -116,7 +116,18 @@ public class GithubService(IDbContextFactory<ApplicationDbContext> _factory) : I
 
         try
         {
-            var points = ProjectHelper.GetProjects().FirstOrDefault(p => p.Id == projectId).ExperiencePoints;
+            var projectDefinition = ProjectHelper.GetProjects().FirstOrDefault(p => p.Id == projectId);
+
+            if (projectDefinition is null)
+            {
+                return new BaseResponse
+                {
+                    Status = ResponseStatus.Fail,
+                    Message = "Project definition not found."
+                };
+            }
+
+            var points = projectDefinition.ExperiencePoints;
 
             using (var context = _factory.CreateDbContext())
             {
@@ -125,6 +136,14 @@ public class GithubService(IDbContextFactory<ApplicationDbContext> _factory) : I
                        .ThenInclude(u => u.UserActivity)
                     .FirstOrDefaultAsync(p => p.ProjectId == projectId && p.GithubUrl.Contains(pullRequestReviewDto.PullRequest.Number.ToString()));
 
+                if (project == null)
+                {
+                    return new BaseResponse
+                    {
+                        Status = ResponseStatus.Fail,
+                        Message = "Project submission not found for this pull request."
+                    };
+                }
                 project.IsPendingNotification = true;
                 project.IsPendingReview = false;
                 project.IsCompleted = true;


### PR DESCRIPTION
## Description

This PR addresses three reliability issues:
1. Prevents duplicate processing when the same approval webhook is delivered more than once.
2. Keeps defensive null payload handling explicit for both PR and PR review payloads.
3. Improves GithubUrl PR number matching so similar PR numbers (for example 12 and 112) cannot be incorrectly matched.

## Related Issue

Closes #348

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / configuration
- [ ] Other: <!-- describe -->

## Implementation Details

- Added idempotency behavior in `MarkAsCompleted(...)`
    - If the project is already completed, return success early.
    - Prevents duplicate XP awards and duplicate activity entries.
- Clarified null guards
    - `ProcessPullRequest(null)` returns fail with "Invalid pull request payload."
    - `MarkAsCompleted(null)` returns fail with "Invalid pull request review payload."
- Tightened PR lookup logic for GithubUrl
    - Matching now uses exact PR number semantics, avoiding false matches between values like 12 and 112.
    - This prevents cross-PR completion/points updates caused by ambiguous suffix matching.
- Added integration test to verify for non duplicates.

## Testing Performed

<!-- Describe how you tested this change. -->

- [x] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [x] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [x] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [x] Added new tests covering the change
- [ ] Manually verified in the browser

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have read the related issue and my implementation matches the requirements
- [x] No sensitive data (credentials, secrets) committed
- [x] All new and existing tests pass
