### PR TITLE
fix: prevent duplicate peer review approvals on PeerReview page

### DIFF
--- a/TCSA.2026.IntegrationTests/GithubServiceTests.cs
+++ b/TCSA.2026.IntegrationTests/GithubServiceTests.cs
@@ -20,7 +20,8 @@ public class GithubServiceTests : IntegrationTestsBase
         httpClientFactoryMock
             .Setup(f => f.CreateClient(It.IsAny<string>()))
             .Returns(new HttpClient());
-        _service = new GithubService(DbContextFactory);
+        var peerReviewPublisherMock = new Mock<IPeerReviewPublisher>();
+        _service = new GithubService(DbContextFactory, peerReviewPublisherMock.Object);
 
         _controller = new GithubWebhookController(_service);
     }

--- a/TCSA.2026.IntegrationTests/PeerReviewTests.cs
+++ b/TCSA.2026.IntegrationTests/PeerReviewTests.cs
@@ -1,4 +1,5 @@
-﻿using TCSA.V2026.Data.Models;
+using TCSA.V2026.Data.Models;
+using TCSA.V2026.Data.Models.Responses;
 using TCSA.V2026.Services;
 
 namespace TCSA.V2026.IntegrationTests;
@@ -60,7 +61,7 @@ public class PeerReviewTests : IntegrationTestsBase
                 {
                     Id = 4,
                     AppUserId = "user1",
-                    ProjectId = (int)ArticleName.PhoneBook, 
+                    ProjectId = (int)ArticleName.PhoneBook,
                     IsPendingReview = true,
                     GithubUrl = $"{codeReviewsUrl}/PhoneBook",
                     DateSubmitted = DateTimeOffset.Now.AddDays(-1)
@@ -199,6 +200,190 @@ public class PeerReviewTests : IntegrationTestsBase
         var projects = await _service.GetProjectsForPeerReview("purpleuser");
         var count = projects.Count;
         Assert.That(count, Is.EqualTo(4));
+    }
+
+    [Test]
+    public async Task MarkCodeReviewAsCompleted_ReviewerNotFound_ReturnsFail()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = 1,
+                AppUserId = "user1",
+                ProjectId = (int)ArticleName.Calculator,
+                IsPendingReview = true,
+                GithubUrl = "https://github.com/TheCSharpAcademy/CodeReviews/Calculator"
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        var response = await _service.MarkCodeReviewAsCompleted("nonexistent-reviewer", 1);
+
+        Assert.That(response.Status, Is.EqualTo(ResponseStatus.Fail));
+        Assert.That(response.Message, Is.EqualTo("Reviewer not found."));
+    }
+
+    [Test]
+    public async Task MarkCodeReviewAsCompleted_DashboardProjectNotFound_ReturnsFail()
+    {
+        var response = await _service.MarkCodeReviewAsCompleted("user2", 9999);
+
+        Assert.That(response.Status, Is.EqualTo(ResponseStatus.Fail));
+        Assert.That(response.Message, Is.EqualTo("Dashboard project not found."));
+    }
+
+    [Test]
+    public async Task MarkCodeReviewAsCompleted_ProjectAlreadyCompleted_ReturnsFail()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = 1,
+                AppUserId = "user1",
+                ProjectId = (int)ArticleName.Calculator,
+                IsCompleted = true,
+                IsPendingReview = false,
+                GithubUrl = "https://github.com/TheCSharpAcademy/CodeReviews/Calculator"
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        var response = await _service.MarkCodeReviewAsCompleted("user2", 1);
+
+        Assert.That(response.Status, Is.EqualTo(ResponseStatus.Fail));
+        Assert.That(response.Message, Is.EqualTo("Project is already marked as completed."));
+    }
+
+    [Test]
+    public async Task MarkCodeReviewAsCompleted_ValidInput_ReturnsSuccess()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = 1,
+                AppUserId = "user1",
+                ProjectId = (int)ArticleName.Calculator,
+                IsPendingReview = true,
+                GithubUrl = "https://github.com/TheCSharpAcademy/CodeReviews/Calculator"
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        var response = await _service.MarkCodeReviewAsCompleted("user2", 1);
+
+        Assert.That(response.Status, Is.EqualTo(ResponseStatus.Success));
+    }
+
+    [Test]
+    public async Task MarkCodeReviewAsCompleted_ValidInput_SetsProjectAsCompleted()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = 1,
+                AppUserId = "user1",
+                ProjectId = (int)ArticleName.Calculator,
+                IsPendingReview = true,
+                GithubUrl = "https://github.com/TheCSharpAcademy/CodeReviews/Calculator"
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        await _service.MarkCodeReviewAsCompleted("user2", 1);
+
+        using var assertContext = DbContextFactory.CreateDbContext();
+        var project = assertContext.DashboardProjects.FirstOrDefault(p => p.Id == 1);
+
+        Assert.That(project, Is.Not.Null);
+        Assert.That(project.IsCompleted, Is.True);
+        Assert.That(project.IsPendingReview, Is.False);
+        Assert.That(project.IsPendingNotification, Is.True);
+        Assert.That(project.DateCompleted, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task MarkCodeReviewAsCompleted_ValidInput_CreatesActivityRecords()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = 1,
+                AppUserId = "user1",
+                ProjectId = (int)ArticleName.Calculator,
+                IsPendingReview = true,
+                GithubUrl = "https://github.com/TheCSharpAcademy/CodeReviews/Calculator"
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        await _service.MarkCodeReviewAsCompleted("user2", 1);
+
+        using var assertContext = DbContextFactory.CreateDbContext();
+        var ownerActivity = assertContext.UserActivity
+            .FirstOrDefault(x => x.AppUserId == "user1" && x.ActivityType == ActivityType.ProjectCompleted);
+        var reviewerActivity = assertContext.UserActivity
+            .FirstOrDefault(x => x.AppUserId == "user2" && x.ActivityType == ActivityType.CodeReviewCompleted);
+
+        Assert.That(ownerActivity, Is.Not.Null);
+        Assert.That(ownerActivity.ProjectId, Is.EqualTo((int)ArticleName.Calculator));
+        Assert.That(reviewerActivity, Is.Not.Null);
+        Assert.That(reviewerActivity.ProjectId, Is.EqualTo((int)ArticleName.Calculator));
+    }
+
+    [Test]
+    public async Task MarkCodeReviewAsCompleted_ValidInput_UpdatesReviewerExperiencePoints()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = 1,
+                AppUserId = "user1",
+                ProjectId = (int)ArticleName.Calculator,
+                IsPendingReview = true,
+                GithubUrl = "https://github.com/TheCSharpAcademy/CodeReviews/Calculator"
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        await _service.MarkCodeReviewAsCompleted("user2", 1);
+
+        using var assertContext = DbContextFactory.CreateDbContext();
+        var reviewer = assertContext.AspNetUsers.FirstOrDefault(u => u.Id == "user2");
+
+        Assert.That(reviewer, Is.Not.Null);
+        Assert.That(reviewer.ExperiencePoints, Is.EqualTo(110));
+        Assert.That(reviewer.ReviewedProjects, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task MarkCodeReviewAsCompleted_ValidInput_UpdatesProjectOwnerExperiencePoints()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = 1,
+                AppUserId = "user1",
+                ProjectId = (int)ArticleName.Calculator,
+                IsPendingReview = true,
+                GithubUrl = "https://github.com/TheCSharpAcademy/CodeReviews/Calculator"
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        await _service.MarkCodeReviewAsCompleted("user2", 1);
+
+        using var assertContext = DbContextFactory.CreateDbContext();
+        var owner = assertContext.AspNetUsers.FirstOrDefault(u => u.Id == "user1");
+
+        Assert.That(owner, Is.Not.Null);
+        Assert.That(owner.ExperiencePoints, Is.EqualTo(10));
     }
 
     [Test]

--- a/TCSA.2026.IntegrationTests/PeerReviewTests.cs
+++ b/TCSA.2026.IntegrationTests/PeerReviewTests.cs
@@ -387,6 +387,111 @@ public class PeerReviewTests : IntegrationTestsBase
     }
 
     [Test]
+    public async Task ReleaseUserFromCodeReview_UserReviewNotFound_ReturnsFail()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = 1,
+                AppUserId = "user10000",
+                ProjectId = (int)ArticleName.Calculator,
+                IsPendingReview = true,
+                GithubUrl = "https://github.com/TheCSharpAcademy/CodeReviews/Calculator"
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        var response = await _service.ReleaseUserFromCodeReview("user10000", 1);
+
+        Assert.That(response.Status, Is.EqualTo(ResponseStatus.Fail));
+        Assert.That(response.Message, Is.EqualTo("User is Null"));
+    }
+
+    [Test]
+    public async Task ReleaseUserFromCodeReview_ProjectAlreadyCompleted_ReturnsFail()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = 1,
+                AppUserId = "user1",
+                ProjectId = (int)ArticleName.Calculator,
+                IsCompleted = true,
+                IsPendingReview = false,
+                GithubUrl = "https://github.com/TheCSharpAcademy/CodeReviews/Calculator"
+            });
+            seedContext.UserReviews.Add(new UserReview
+            {
+                AppUserId = "user2",
+                DashboardProjectId = 1
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        var response = await _service.ReleaseUserFromCodeReview("user2", 1);
+
+        Assert.That(response.Status, Is.EqualTo(ResponseStatus.Fail));
+        Assert.That(response.Message, Is.EqualTo("Project is already completed and cannot be released."));
+    }
+
+    [Test]
+    public async Task ReleaseUserFromCodeReview_ValidInput_ReturnsSuccess()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = 1,
+                AppUserId = "user1",
+                ProjectId = (int)ArticleName.Calculator,
+                IsPendingReview = true,
+                GithubUrl = "https://github.com/TheCSharpAcademy/CodeReviews/Calculator"
+            });
+            seedContext.UserReviews.Add(new UserReview
+            {
+                AppUserId = "user2",
+                DashboardProjectId = 1
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        var response = await _service.ReleaseUserFromCodeReview("user2", 1);
+
+        Assert.That(response.Status, Is.EqualTo(ResponseStatus.Success));
+    }
+
+    [Test]
+    public async Task ReleaseUserFromCodeReview_ValidInput_RemovesUserReview()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.DashboardProjects.Add(new DashboardProject
+            {
+                Id = 1,
+                AppUserId = "user1",
+                ProjectId = (int)ArticleName.Calculator,
+                IsPendingReview = true,
+                GithubUrl = "https://github.com/TheCSharpAcademy/CodeReviews/Calculator"
+            });
+            seedContext.UserReviews.Add(new UserReview
+            {
+                AppUserId = "user2",
+                DashboardProjectId = 1
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        await _service.ReleaseUserFromCodeReview("user2", 1);
+
+        using var assertContext = DbContextFactory.CreateDbContext();
+        var userReview = assertContext.UserReviews.FirstOrDefault(x => x.AppUserId == "user2" && x.DashboardProjectId == 1);
+
+        Assert.That(userReview, Is.Null);
+    }
+
+    [Test]
     public async Task GetProjectsForPeerReview_GivenUserCompletedMVC_canSeeMVCProjects()
     {
         var codeReviewsUrl = "https://github.com/TheCSharpAcademy/CodeReviews";

--- a/TCSA.V2026.EndToEndTests/PeerReviewAutoRefreshTests.cs
+++ b/TCSA.V2026.EndToEndTests/PeerReviewAutoRefreshTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.Playwright;
+using System.Text;
+
+namespace TCSA.V2026.EndToEndTests;
+
+[TestFixture]
+[NonParallelizable]
+public class PeerReviewAutoRefreshTests : EndToEndTestsBase
+{
+    private const long HabitLoggerRepoId = 573675655;
+    private const int HabitLoggerPrNumber = 392;
+
+    [Test]
+    public async Task PeerReviewPage_AutoRefreshes_WhenGithubWebhookApprovesAssignedProject()
+    {
+        // Arrange
+        await LoginAsTestUserAsync("user1@example.com", "Password123!");
+        await Page.GotoAsync($"{BaseUrl}/dashboard/reviews");
+
+        var habitLoggerCard = Page.Locator(".peer-review-card").Filter(new() { HasText = "Habit Logger" });
+        await habitLoggerCard.GetByRole(AriaRole.Button, new() { Name = "Pick" }).ClickAsync();
+        await Expect(habitLoggerCard.GetByRole(AriaRole.Button, new() { Name = "Tick" })).ToBeVisibleAsync();
+
+        // Act
+        await SendGithubPullRequestWebhook(HabitLoggerRepoId, HabitLoggerPrNumber);
+
+        // Assert
+        await Expect(habitLoggerCard).Not.ToBeVisibleAsync();
+    }
+
+    private async Task SendGithubPullRequestWebhook(long repoId, int prNumber)
+    {
+        using var client = Factory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/github")
+        {
+            Content = new StringContent(
+                $$"""
+                {
+                    "action": "submitted",
+                    "repository": {
+                        "id": {{repoId}}
+                    },
+                    "review": {
+                        "state": "approved"
+                    },
+                    "pull_request": {
+                        "number": {{prNumber}},
+                        "html_url": "",
+                        "user": {
+                            "login": ""
+                        }
+                    }
+                }
+                """,
+                Encoding.UTF8,
+                "application/json")
+        };
+        request.Headers.Add("X-GitHub-Event", "pull_request_review");
+        await client.SendAsync(request);
+    }
+}

--- a/TCSA.V2026.UnitTests/Components/Pages/Dashboard/PeerReviewsTests.cs
+++ b/TCSA.V2026.UnitTests/Components/Pages/Dashboard/PeerReviewsTests.cs
@@ -22,6 +22,7 @@ public class PeerReviewsTests : BunitContext
     private readonly Mock<IProjectService> _projectServiceMock = new();
     private readonly Mock<IUserService> _userServiceMock = new();
     private readonly Mock<IPeerReviewService> _peerReviewServiceMock = new();
+    private readonly Mock<IPeerReviewPublisher> _peerReviewPublisherMock = new();
 
     private const string TestUserId = "test-user-id";
     private const int TestDashboardProjectId = 42;
@@ -71,6 +72,7 @@ public class PeerReviewsTests : BunitContext
         Services.AddSingleton(_projectServiceMock.Object);
         Services.AddSingleton(_userServiceMock.Object);
         Services.AddSingleton(_peerReviewServiceMock.Object);
+        Services.AddSingleton(_peerReviewPublisherMock.Object);
         Services.AddMudServices();
     }
 

--- a/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
@@ -166,6 +166,7 @@
         await InvokeAsync(async () =>
         {
             AvailableProjects = await PeerReviewService.GetProjectsForPeerReview(UserId);
+            User = await UserService.GetUserById(UserId);
             StateHasChanged();
         });
     }

--- a/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
@@ -133,6 +133,7 @@
 
     private bool IsLoading = true;
     private string UserId = string.Empty;
+    private Guid _subscriptionId;
     private TimeSpan LoadTime;
     private HashSet<int> _processingIds = new();
 
@@ -155,11 +156,13 @@
 
         IsLoading = false;
 
-        Publisher.Subscribe(UserId, OnReviewCompletedAsync);
+        _subscriptionId = Publisher.Subscribe(OnReviewCompletedAsync);
     }
 
     private async Task OnReviewCompletedAsync(ReviewCompletedEvent @event)
     {
+        if (@event.ReviewerId != UserId) return;
+
         await InvokeAsync(async () =>
         {
             AvailableProjects = await PeerReviewService.GetProjectsForPeerReview(UserId);
@@ -169,7 +172,7 @@
 
     public void Dispose()
     {
-        Publisher.Unsubscribe(UserId);
+        Publisher.Unsubscribe(_subscriptionId);
     }
 
     private async Task AssignMyself(int dashboardProjectId)

--- a/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
@@ -165,8 +165,13 @@
 
         await InvokeAsync(async () =>
         {
+            IsLoading = true;
+            StateHasChanged();
+
             AvailableProjects = await PeerReviewService.GetProjectsForPeerReview(UserId);
             User = await UserService.GetUserById(UserId);
+
+            IsLoading = false;
             StateHasChanged();
         });
     }

--- a/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/PeerReviews.razor
@@ -4,12 +4,14 @@
 @using TCSA.V2026.Data.Curriculum
 @using TCSA.V2026.Data.DTOs
 @using TCSA.V2026.Data.Enums
+@using TCSA.V2026.Data.Events
 @using TCSA.V2026.Data.Models
 @using TCSA.V2026.Data.Models.Responses
 @using TCSA.V2026.Components.UI
 @using TCSA.V2026.Helpers
 @using TCSA.V2026.Services
 @attribute [Authorize]
+@implements IDisposable
 
 <PageTitle>Peer Reviews</PageTitle>
 
@@ -121,6 +123,7 @@
     [Inject] private IProjectService ProjectService { get; set; }
     [Inject] private IUserService UserService { get; set; }
     [Inject] private IPeerReviewService PeerReviewService { get; set; }
+    [Inject] private IPeerReviewPublisher Publisher { get; set; }
     [Inject] private ISnackbar Snackbar { get; set; }
     [Inject] private IJSRuntime JS { get; set; }
 
@@ -151,6 +154,22 @@
         LoadTime = DateTime.UtcNow - startTime;
 
         IsLoading = false;
+
+        Publisher.Subscribe(UserId, OnReviewCompletedAsync);
+    }
+
+    private async Task OnReviewCompletedAsync(ReviewCompletedEvent @event)
+    {
+        await InvokeAsync(async () =>
+        {
+            AvailableProjects = await PeerReviewService.GetProjectsForPeerReview(UserId);
+            StateHasChanged();
+        });
+    }
+
+    public void Dispose()
+    {
+        Publisher.Unsubscribe(UserId);
     }
 
     private async Task AssignMyself(int dashboardProjectId)

--- a/TCSA.V2026/Data/Events/ReviewCompletedEvent.cs
+++ b/TCSA.V2026/Data/Events/ReviewCompletedEvent.cs
@@ -1,3 +1,3 @@
 namespace TCSA.V2026.Data.Events;
 
-public record ReviewCompletedEvent(string ReviewerId, int DashboardProjectId);
+public record ReviewCompletedEvent(string ReviewerId);

--- a/TCSA.V2026/Data/Events/ReviewCompletedEvent.cs
+++ b/TCSA.V2026/Data/Events/ReviewCompletedEvent.cs
@@ -1,0 +1,3 @@
+namespace TCSA.V2026.Data.Events;
+
+public record ReviewCompletedEvent(string ReviewerId, int DashboardProjectId);

--- a/TCSA.V2026/Program.cs
+++ b/TCSA.V2026/Program.cs
@@ -69,6 +69,7 @@ builder.Services.AddScoped<IAccountabilityBuddyService, AccountabilityBuddyServi
 builder.Services.AddScoped<IDonateService, DonateService>();
 builder.Services.AddHttpClient();
 builder.Services.AddSingleton<ICustomEmailSender, EmailSender>();
+builder.Services.AddSingleton<IPeerReviewPublisher, PeerReviewPublisher>();
 
 builder.Services.AddControllers();
 

--- a/TCSA.V2026/Services/GithubService.cs
+++ b/TCSA.V2026/Services/GithubService.cs
@@ -209,7 +209,7 @@ public class GithubService(IDbContextFactory<ApplicationDbContext> _factory, IPe
                 await context.SaveChangesAsync();
 
                 if (!string.IsNullOrEmpty(reviewerUserId))
-                    await _publisher.Publish(new ReviewCompletedEvent(reviewerUserId, completedProjectId));
+                    await _publisher.Publish(new ReviewCompletedEvent(reviewerUserId));
             }
             return new BaseResponse
             {

--- a/TCSA.V2026/Services/GithubService.cs
+++ b/TCSA.V2026/Services/GithubService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using TCSA.V2026.Data;
 using TCSA.V2026.Data.Curriculum;
 using TCSA.V2026.Data.DTOs;
+using TCSA.V2026.Data.Events;
 using TCSA.V2026.Data.Models;
 using TCSA.V2026.Data.Models.Responses;
 using TCSA.V2026.Helpers;
@@ -14,7 +15,7 @@ public interface IGithubService
     Task<BaseResponse> ProcessPullRequest(PullRequestDto? pullRequestDto);
 }
 
-public class GithubService(IDbContextFactory<ApplicationDbContext> _factory) : IGithubService
+public class GithubService(IDbContextFactory<ApplicationDbContext> _factory, IPeerReviewPublisher _publisher) : IGithubService
 {
     public async Task<BaseResponse> ProcessPullRequest(PullRequestDto? pullRequestDto)
     {
@@ -188,8 +189,12 @@ public class GithubService(IDbContextFactory<ApplicationDbContext> _factory) : I
                         .ThenInclude(u => u.UserActivity)
                     .FirstOrDefaultAsync(r => r.DashboardProjectId == project.Id);
 
+                string reviewerUserId = string.Empty;
+                int completedProjectId = project.Id;
+
                 if (review != null)
                 {
+                    reviewerUserId = review.User.Id;
                     review.User.ExperiencePoints = review.User.ExperiencePoints + points;
                     review.User.ReviewedProjects = review.User.ReviewedProjects + 1;
                     review.User.ReviewExperiencePoints = review.User.ReviewExperiencePoints + points;
@@ -202,6 +207,9 @@ public class GithubService(IDbContextFactory<ApplicationDbContext> _factory) : I
                 }
 
                 await context.SaveChangesAsync();
+
+                if (!string.IsNullOrEmpty(reviewerUserId))
+                    await _publisher.Publish(new ReviewCompletedEvent(reviewerUserId, completedProjectId));
             }
             return new BaseResponse
             {

--- a/TCSA.V2026/Services/PeerReviewPublisher.cs
+++ b/TCSA.V2026/Services/PeerReviewPublisher.cs
@@ -1,0 +1,43 @@
+using System.Collections.Concurrent;
+using TCSA.V2026.Data.Events;
+
+namespace TCSA.V2026.Services;
+
+public interface IPeerReviewPublisher
+{
+    void Subscribe(string userId, Func<ReviewCompletedEvent, Task> handler);
+    void Unsubscribe(string userId);
+    Task Publish(ReviewCompletedEvent @event);
+}
+
+public class PeerReviewPublisher : IPeerReviewPublisher
+{
+    private readonly ConcurrentDictionary<string, Func<ReviewCompletedEvent, Task>> _subscribers = new();
+    private readonly ILogger<PeerReviewPublisher> _logger;
+
+    public PeerReviewPublisher(ILogger<PeerReviewPublisher> logger)
+    {
+        _logger = logger;
+    }
+
+    public void Subscribe(string userId, Func<ReviewCompletedEvent, Task> handler)
+        => _subscribers[userId] = handler;
+
+    public void Unsubscribe(string userId)
+        => _subscribers.TryRemove(userId, out _);
+
+    public async Task Publish(ReviewCompletedEvent @event)
+    {
+        if (_subscribers.TryGetValue(@event.ReviewerId, out var handler))
+        {
+            try
+            {
+                await handler(@event);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while publishing the review completed event for reviewer {ReviewerId}", @event.ReviewerId);
+            }
+        }
+    }
+}

--- a/TCSA.V2026/Services/PeerReviewPublisher.cs
+++ b/TCSA.V2026/Services/PeerReviewPublisher.cs
@@ -5,14 +5,14 @@ namespace TCSA.V2026.Services;
 
 public interface IPeerReviewPublisher
 {
-    void Subscribe(string userId, Func<ReviewCompletedEvent, Task> handler);
-    void Unsubscribe(string userId);
+    Guid Subscribe(Func<ReviewCompletedEvent, Task> handler);
+    void Unsubscribe(Guid subscriptionId);
     Task Publish(ReviewCompletedEvent @event);
 }
 
 public class PeerReviewPublisher : IPeerReviewPublisher
 {
-    private readonly ConcurrentDictionary<string, Func<ReviewCompletedEvent, Task>> _subscribers = new();
+    private readonly ConcurrentDictionary<Guid, Func<ReviewCompletedEvent, Task>> _subscribers = new();
     private readonly ILogger<PeerReviewPublisher> _logger;
 
     public PeerReviewPublisher(ILogger<PeerReviewPublisher> logger)
@@ -20,15 +20,19 @@ public class PeerReviewPublisher : IPeerReviewPublisher
         _logger = logger;
     }
 
-    public void Subscribe(string userId, Func<ReviewCompletedEvent, Task> handler)
-        => _subscribers[userId] = handler;
+    public Guid Subscribe(Func<ReviewCompletedEvent, Task> handler)
+    {
+        var id = Guid.NewGuid();
+        _subscribers[id] = handler;
+        return id;
+    }
 
-    public void Unsubscribe(string userId)
-        => _subscribers.TryRemove(userId, out _);
+    public void Unsubscribe(Guid subscriptionId)
+        => _subscribers.TryRemove(subscriptionId, out _);
 
     public async Task Publish(ReviewCompletedEvent @event)
     {
-        if (_subscribers.TryGetValue(@event.ReviewerId, out var handler))
+        foreach (var handler in _subscribers.Values)
         {
             try
             {

--- a/TCSA.V2026/Services/PeerReviewService.cs
+++ b/TCSA.V2026/Services/PeerReviewService.cs
@@ -196,6 +196,13 @@ public class PeerReviewService(IDbContextFactory<ApplicationDbContext> _factory)
                     .Include(x => x.UserActivity.Where(x => x.ActivityType == ActivityType.CodeReviewCompleted))
                     .FirstOrDefaultAsync(x => x.Id == reviewerId);
 
+                if (reviewer is null)
+                {
+                    result.Message = "Reviewer not found.";
+                    result.Status = ResponseStatus.Fail;
+                    return result;
+                }
+
                 var reviewedProjects = reviewer.UserActivity;
 
                 var dashboardProject = await context.DashboardProjects

--- a/TCSA.V2026/Services/PeerReviewService.cs
+++ b/TCSA.V2026/Services/PeerReviewService.cs
@@ -215,6 +215,14 @@ public class PeerReviewService(IDbContextFactory<ApplicationDbContext> _factory)
                     result.Status = ResponseStatus.Fail;
                     return result;
                 }
+
+                if (dashboardProject.IsCompleted)
+                {
+                    result.Message = "Project is already marked as completed.";
+                    result.Status = ResponseStatus.Fail;
+                    return result;
+                }
+
                 var academyProject = ProjectHelper.GetProjects().FirstOrDefault(x => x.Id == dashboardProject.ProjectId);
 
                 dashboardProject.IsPendingReview = false;

--- a/TCSA.V2026/Services/PeerReviewService.cs
+++ b/TCSA.V2026/Services/PeerReviewService.cs
@@ -192,9 +192,9 @@ public class PeerReviewService(IDbContextFactory<ApplicationDbContext> _factory)
         {
             using (var context = _factory.CreateDbContext())
             {
-                var reviewer = context.Users
+                var reviewer = await context.Users
                     .Include(x => x.UserActivity.Where(x => x.ActivityType == ActivityType.CodeReviewCompleted))
-                    .FirstOrDefault(x => x.Id == reviewerId);
+                    .FirstOrDefaultAsync(x => x.Id == reviewerId);
 
                 var reviewedProjects = reviewer.UserActivity;
 

--- a/TCSA.V2026/Services/PeerReviewService.cs
+++ b/TCSA.V2026/Services/PeerReviewService.cs
@@ -57,11 +57,19 @@ public class PeerReviewService(IDbContextFactory<ApplicationDbContext> _factory)
             using (var context = _factory.CreateDbContext())
             {
                 var userReview = await context.UserReviews
+                    .Include(x => x.DashboardProject)
                     .FirstOrDefaultAsync(x => x.AppUserId == userId && x.DashboardProjectId == id);
 
                 if (userReview is null)
                 {
                     result.Message = "User is Null";
+                    result.Status = ResponseStatus.Fail;
+                    return result;
+                }
+
+                if (userReview.DashboardProject.IsCompleted)
+                {
+                    result.Message = "Project is already completed and cannot be released.";
                     result.Status = ResponseStatus.Fail;
                     return result;
                 }

--- a/TCSA.V2026/Services/PeerReviewService.cs
+++ b/TCSA.V2026/Services/PeerReviewService.cs
@@ -209,6 +209,12 @@ public class PeerReviewService(IDbContextFactory<ApplicationDbContext> _factory)
                     .Include(dp => dp.AppUser)
                     .FirstOrDefaultAsync(x => x.Id == dashboardProjectId);
 
+                if (dashboardProject is null)
+                {
+                    result.Message = "Dashboard project not found.";
+                    result.Status = ResponseStatus.Fail;
+                    return result;
+                }
                 var academyProject = ProjectHelper.GetProjects().FirstOrDefault(x => x.Id == dashboardProject.ProjectId);
 
                 dashboardProject.IsPendingReview = false;


### PR DESCRIPTION
## Description

Fixes a problem with duplicate peer review approvals, and adds real-time UI updates so the reviewer's project list refreshes automatically after a review is completed via webhook. With this change, the reviewer won't see stale data and hence won't try to mark a given project as completed or release himself from a project that has already been completed.

## Related Issue

Closes #419

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / configuration
- [ ] Other: <!-- describe -->

## Implementation Details

  - `PeerReviewService.MarkCodeReviewAsCompleted` now checks `DashboardProject.IsCompleted` before proceeding.
  - `PeerReviewService.ReleaseUserFromCodeReview` similarly checks `IsCompleted` on the loaded `DashboardProject` before removing the `UserReview` row, preventing removal for already completed projects.
  - Reviewer lookup in `PeerReviewService.MarkCodeReviewAsCompleted` was changed from synchronous `FirstOrDefault` to `FirstOrDefaultAsync`, with an explicit null guard that short-circuits with a fail response when the reviewer is not found.

  - Added `ReviewCompletedEvent` record and `IPeerReviewPublisher` / `PeerReviewPublisher`.
  - `GithubService.MarkAsCompleted` publishes a `ReviewCompletedEvent` after saving reviewer XP, so connected browser sessions in `PeerReviewPublisher` are notified immediately.
  - `PeerReviews.razor` subscribes on `OnInitializedAsync` to `PeerReviewPublisher`, reloads its data inside `OnReviewCompletedAsync` on receipt of an event scoped to the current user, and unsubscribes via `IDisposable.Dispose`.
  - `IPeerReviewPublisher` is registered as a singleton in `Program.cs` so all scoped Blazor circuits share the same publisher instance.
  - Tests for `ReleaseUserFromCodeReview` covering:
     - reviewer not found, dashboard project not found
     - project already completed
     - successful release
  - Tests for `CompleteCodeReview` covering:
     - project already marked as completed
     - successful completion
  - `PeerReviewAutoRefreshTests` which verify that page is automatically refreshed after github webhook request for approving assigned project is completed.

## Testing Performed

<!-- Describe how you tested this change. -->

- [x] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [x] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [x] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [x] Added new tests covering the change
- [x] Manually verified in the browser

## Screenshots

https://www.loom.com/share/48c03225891c4fd1ba6fb099214cf905

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have read the related issue and my implementation matches the requirements
- [x] No sensitive data (credentials, secrets) committed
- [x] All new and existing tests pass
