### PR TITLE
feat: expand community issues to support other open source projects

### DIFF
--- a/TCSA.2026.IntegrationTests/CommunityServiceTests.cs
+++ b/TCSA.2026.IntegrationTests/CommunityServiceTests.cs
@@ -1,4 +1,7 @@
+using TCSA.V2026.Data.Enums;
 using TCSA.V2026.Data.Models;
+using TCSA.V2026.Data.Models.Responses;
+using TCSA.V2026.Helpers.Constants;
 using TCSA.V2026.Services;
 
 namespace TCSA.V2026.IntegrationTests;
@@ -24,8 +27,8 @@ public class CommunityServiceTests : IntegrationTestsBase
     [Test]
     public async Task IssuesShouldHaveNoDupes()
     {
-        await _service.CreateIssue(IssueType.Feature, "issueUrl.com", "Test Issue 1", "user1");
-        await _service.CreateIssue(IssueType.Feature, "issueUrl.com", "Test Issue 1", "user1");
+        await _service.CreateIssue(IssueType.Feature, $"{UrlConstants.TCSARepositoryIssuesUrl}/1", "Test Issue 1", CommunityProject.TCSA);
+        await _service.CreateIssue(IssueType.Feature, $"{UrlConstants.TCSARepositoryIssuesUrl}/1", "Test Issue 1", CommunityProject.TCSA);
 
         using var verifyContext = DbContextFactory.CreateDbContext();
 
@@ -34,5 +37,37 @@ public class CommunityServiceTests : IntegrationTestsBase
         .ToList();
 
         Assert.That(list.Count, Is.EqualTo(1));
+    }
+
+    [TestCase("https://github.com/random-org/random-repo/issues/1")]
+    [TestCase("https://github.com/the-csharp-academy/TCSA.V2026/pull/1")]
+    [TestCase("https://github.com/the-csharp-academy/TCSA.V2026/issues/")]
+    [TestCase("https://github.com/the-csharp-academy/TCSA.V2026/issues/abc")]
+    [TestCase("not-a-url")]
+    [TestCase("")]
+    public async Task IssueWithInvalidUrlShouldNotBeSaved(string invalidUrl)
+    {
+        var result = await _service.CreateIssue(IssueType.Feature, invalidUrl, "Invalid Issue", CommunityProject.TCSA);
+
+        using var verifyContext = DbContextFactory.CreateDbContext();
+        var count = verifyContext.Issues.Count();
+
+        Assert.That(result.Status, Is.EqualTo(ResponseStatus.Fail));
+        Assert.That(count, Is.EqualTo(0));
+    }
+
+    [TestCase("https://github.com/the-csharp-academy/TCSA.KnowTheCity/issues/1")]
+    [TestCase("https://github.com/the-csharp-academy/TCSA.V2026/issues/1")]
+    public async Task IssueWithValidUrlShouldBeSaved(string validUrl)
+    {
+        CommunityProject project = validUrl.Contains("KnowTheCity") ? CommunityProject.KnowTheCity : CommunityProject.TCSA;
+
+        var result = await _service.CreateIssue(IssueType.Feature, validUrl, "Valid Issue", project);
+
+        using var verifyContext = DbContextFactory.CreateDbContext();
+        var count = verifyContext.Issues.Count();
+
+        Assert.That(result.Status, Is.EqualTo(ResponseStatus.Success));
+        Assert.That(count, Is.EqualTo(1));
     }
 }

--- a/TCSA.V2026.UnitTests/Components/Pages/Dashboard/CommunityTests.cs
+++ b/TCSA.V2026.UnitTests/Components/Pages/Dashboard/CommunityTests.cs
@@ -118,7 +118,6 @@ public class CommunityTests : BunitContext
         _dialogServiceMock
             .Setup(s => s.ShowAsync<TCSASubmitIssueDialog>(
                 It.IsAny<string>(),
-                It.IsAny<DialogParameters<TCSASubmitIssueDialog>>(),
                 It.IsAny<DialogOptions>()))
             .Returns(tcs.Task);
 
@@ -146,7 +145,6 @@ public class CommunityTests : BunitContext
         _dialogServiceMock.Verify(
             s => s.ShowAsync<TCSASubmitIssueDialog>(
                 It.IsAny<string>(),
-                It.IsAny<DialogParameters<TCSASubmitIssueDialog>>(),
                 It.IsAny<DialogOptions>()),
             Times.Once);
     }
@@ -160,7 +158,6 @@ public class CommunityTests : BunitContext
         dialogServiceMock
             .Setup(s => s.ShowAsync<TCSASubmitIssueDialog>(
                 It.IsAny<string>(),
-                It.IsAny<DialogParameters<TCSASubmitIssueDialog>>(),
                 It.IsAny<DialogOptions>()))
             .Returns(tcs.Task);
 
@@ -194,9 +191,9 @@ public class CommunityTests : BunitContext
         var tcs = new TaskCompletionSource<IDialogReference>();
         var dialogServiceMock = new Mock<IDialogService>();
         dialogServiceMock
-            .Setup(s => s.ShowAsync<TCSASubmitProjectDialog>(
+            .Setup(s => s.ShowAsync<TCSASubmitIssueToReviewDialog>(
                 It.IsAny<string>(),
-                It.IsAny<DialogParameters<TCSASubmitProjectDialog>>(),
+                It.IsAny<DialogParameters<TCSASubmitIssueToReviewDialog>>(),
                 It.IsAny<DialogOptions>()))
             .Returns(tcs.Task);
 
@@ -224,9 +221,9 @@ public class CommunityTests : BunitContext
 
         // Assert
         dialogServiceMock.Verify(
-            s => s.ShowAsync<TCSASubmitProjectDialog>(
+            s => s.ShowAsync<TCSASubmitIssueToReviewDialog>(
                 It.IsAny<string>(),
-                It.IsAny<DialogParameters<TCSASubmitProjectDialog>>(),
+                It.IsAny<DialogParameters<TCSASubmitIssueToReviewDialog>>(),
                 It.IsAny<DialogOptions>()),
             Times.Once);
     }
@@ -238,9 +235,9 @@ public class CommunityTests : BunitContext
         var tcs = new TaskCompletionSource<IDialogReference>();
         var dialogServiceMock = new Mock<IDialogService>();
         dialogServiceMock
-            .Setup(s => s.ShowAsync<TCSASubmitProjectDialog>(
+            .Setup(s => s.ShowAsync<TCSASubmitIssueToReviewDialog>(
                 It.IsAny<string>(),
-                It.IsAny<DialogParameters<TCSASubmitProjectDialog>>(),
+                It.IsAny<DialogParameters<TCSASubmitIssueToReviewDialog>>(),
                 It.IsAny<DialogOptions>()))
             .Returns(tcs.Task);
 

--- a/TCSA.V2026.UnitTests/Components/UI/DialogTests.cs
+++ b/TCSA.V2026.UnitTests/Components/UI/DialogTests.cs
@@ -7,6 +7,7 @@ using MudBlazor;
 using MudBlazor.Services;
 using TCSA.V2026.Components.UI;
 using TCSA.V2026.Data.DTOs;
+using TCSA.V2026.Data.Enums;
 using TCSA.V2026.Data.Helpers;
 using TCSA.V2026.Data.Models;
 using TCSA.V2026.Data.Models.Responses;
@@ -72,11 +73,10 @@ public class DialogTests : BunitContext
         var tcs = new TaskCompletionSource<BaseResponse>();
 
         _communityServiceMock
-            .Setup(s => s.CreateIssue(It.IsAny<IssueType>(), It.IsAny<string>(), It.IsAny<string>(), TestUserId))
+            .Setup(s => s.CreateIssue(It.IsAny<IssueType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CommunityProject>()))
             .Returns(tcs.Task);
 
         var parameters = new DialogParameters<TCSASubmitIssueDialog>();
-        parameters.Add(x => x.UserId, TestUserId);
         var providerCut = await ShowDialog(parameters);
 
         // Act
@@ -88,7 +88,7 @@ public class DialogTests : BunitContext
 
         // Assert
         _communityServiceMock.Verify(
-            s => s.CreateIssue(It.IsAny<IssueType>(), It.IsAny<string>(), It.IsAny<string>(), TestUserId),
+            s => s.CreateIssue(It.IsAny<IssueType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CommunityProject>()),
             Times.Once);
     }
 
@@ -99,11 +99,10 @@ public class DialogTests : BunitContext
         var tcs = new TaskCompletionSource<BaseResponse>();
 
         _communityServiceMock
-            .Setup(s => s.CreateIssue(It.IsAny<IssueType>(), It.IsAny<string>(), It.IsAny<string>(), TestUserId))
+            .Setup(s => s.CreateIssue(It.IsAny<IssueType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CommunityProject>()))
             .Returns(tcs.Task);
 
         var parameters = new DialogParameters<TCSASubmitIssueDialog>();
-        parameters.Add(x => x.UserId, TestUserId);
         var providerCut = await ShowDialog(parameters);
 
         // Act
@@ -115,7 +114,7 @@ public class DialogTests : BunitContext
     }
 
     [Test]
-    public async Task SubmitProjectDialog_SubmitButton_WhenClickedTwiceWhileProcessing_CallsSubmitIssueToReviewOnce()
+    public async Task SubmitIssueToReviewDialog_SubmitButton_WhenClickedTwiceWhileProcessing_CallsSubmitIssueToReviewOnce()
     {
         // Arrange
         var tcs = new TaskCompletionSource<BaseResponse>();
@@ -124,10 +123,10 @@ public class DialogTests : BunitContext
             .Setup(s => s.SubmitIssueToReview(TestProjectId, It.IsAny<string>()))
             .Returns(tcs.Task);
 
-        var parameters = new DialogParameters<TCSASubmitProjectDialog>();
+        var parameters = new DialogParameters<TCSASubmitIssueToReviewDialog>();
         parameters.Add(x => x.ProjectId, TestProjectId);
-        parameters.Add(x => x.IsIssue, true);
-        parameters.Add(x => x.User, _testUser);
+        parameters.Add(x => x.CommunityProject, CommunityProject.TCSA);
+        parameters.Add(x => x.CurrentGithubUrl, "https://github.com/the-csharp-academy/TCSA.V2026/pull/1");
         var providerCut = await ShowDialog(parameters);
 
         // Act
@@ -144,7 +143,7 @@ public class DialogTests : BunitContext
     }
 
     [Test]
-    public async Task SubmitProjectDialog_SubmitButton_WhileProcessing_IsDisabled()
+    public async Task SubmitIssueToReviewDialog_SubmitButton_WhileProcessing_IsDisabled()
     {
         // Arrange
         var tcs = new TaskCompletionSource<BaseResponse>();
@@ -153,10 +152,10 @@ public class DialogTests : BunitContext
             .Setup(s => s.SubmitIssueToReview(TestProjectId, It.IsAny<string>()))
             .Returns(tcs.Task);
 
-        var parameters = new DialogParameters<TCSASubmitProjectDialog>();
+        var parameters = new DialogParameters<TCSASubmitIssueToReviewDialog>();
         parameters.Add(x => x.ProjectId, TestProjectId);
-        parameters.Add(x => x.IsIssue, true);
-        parameters.Add(x => x.User, _testUser);
+        parameters.Add(x => x.CommunityProject, CommunityProject.TCSA);
+        parameters.Add(x => x.CurrentGithubUrl, "https://github.com/the-csharp-academy/TCSA.V2026/pull/1");
         var providerCut = await ShowDialog(parameters);
 
         // Act

--- a/TCSA.V2026.UnitTests/Helpers/UrlHelperTests.cs
+++ b/TCSA.V2026.UnitTests/Helpers/UrlHelperTests.cs
@@ -1,0 +1,63 @@
+using TCSA.V2026.Data.Enums;
+using TCSA.V2026.Helpers;
+using TCSA.V2026.Helpers.Constants;
+
+namespace TCSA.V2026.UnitTests.Helpers;
+
+[TestFixture]
+public class UrlHelperTests
+{
+    [TestCase($"{UrlConstants.TCSARepositoryIssuesUrl}/1", CommunityProject.TCSA, true)]
+    [TestCase($"{UrlConstants.TCSARepositoryIssuesUrl}/999", CommunityProject.TCSA, true)]
+    [TestCase($"{UrlConstants.KnowTheCityRepositoryIssuesUrl}/1", CommunityProject.KnowTheCity, true)]
+    [TestCase($"{UrlConstants.KnowTheCityRepositoryIssuesUrl}/999", CommunityProject.KnowTheCity, true)]
+    [TestCase("https://github.com/random-org/random-repo/issues/1", CommunityProject.TCSA, false)]
+    [TestCase($"{UrlConstants.TCSARepositoryIssuesUrl}/1", CommunityProject.KnowTheCity, false)]
+    [TestCase($"{UrlConstants.KnowTheCityRepositoryIssuesUrl}/1", CommunityProject.TCSA, false)]
+    [TestCase($"{UrlConstants.TCSARepositoryPullUrl}/1", CommunityProject.TCSA, false)]
+    [TestCase($"{UrlConstants.TCSARepositoryIssuesUrl}/", CommunityProject.TCSA, false)]
+    [TestCase($"{UrlConstants.TCSARepositoryIssuesUrl}/abc", CommunityProject.TCSA, false)]
+    [TestCase($"{UrlConstants.TCSARepositoryIssuesUrl}", CommunityProject.TCSA, false)]
+    [TestCase("not-a-url", CommunityProject.TCSA, false)]
+    [TestCase("", CommunityProject.TCSA, false)]
+    public void IsValidCommunityProjectIssueUrl_ShouldReturnExpected(string url, CommunityProject project, bool expected)
+    {
+        var result = UrlHelper.IsValidCommunityProjectIssueUrl(url, project);
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void IsValidCommunityProjectIssueUrl_ShouldThrow_WhenProjectIsInvalid()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            UrlHelper.IsValidCommunityProjectIssueUrl("https://github.com/any/repo/issues/1", (CommunityProject)9999));
+    }
+
+    [TestCase($"{UrlConstants.TCSARepositoryPullUrl}/1", CommunityProject.TCSA, true)]
+    [TestCase($"{UrlConstants.TCSARepositoryPullUrl}/999", CommunityProject.TCSA, true)]
+    [TestCase($"{UrlConstants.KnowTheCityRepositoryPullUrl}/1", CommunityProject.KnowTheCity, true)]
+    [TestCase($"{UrlConstants.KnowTheCityRepositoryPullUrl}/999", CommunityProject.KnowTheCity, true)]
+    [TestCase("https://github.com/random-org/random-repo/pull/1", CommunityProject.TCSA, false)]
+    [TestCase($"{UrlConstants.TCSARepositoryPullUrl}/1", CommunityProject.KnowTheCity, false)]
+    [TestCase($"{UrlConstants.KnowTheCityRepositoryPullUrl}/1", CommunityProject.TCSA, false)]
+    [TestCase($"{UrlConstants.TCSARepositoryIssuesUrl}/1", CommunityProject.TCSA, false)]
+    [TestCase($"{UrlConstants.TCSARepositoryPullUrl}/", CommunityProject.TCSA, false)]
+    [TestCase($"{UrlConstants.TCSARepositoryPullUrl}/abc", CommunityProject.TCSA, false)]
+    [TestCase($"{UrlConstants.TCSARepositoryPullUrl}", CommunityProject.TCSA, false)]
+    [TestCase("not-a-url", CommunityProject.TCSA, false)]
+    [TestCase("", CommunityProject.TCSA, false)]
+    public void IsValidCommunityProjectPrUrl_ShouldReturnExpected(string url, CommunityProject project, bool expected)
+    {
+        var result = UrlHelper.IsValidCommunityProjectPrUrl(url, project);
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void IsValidCommunityProjectPrUrl_ShouldThrow_WhenProjectIsInvalid()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            UrlHelper.IsValidCommunityProjectPrUrl("https://github.com/any/repo/pull/1", (CommunityProject)9999));
+    }
+}

--- a/TCSA.V2026/Components/Pages/Dashboard/Community.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Community.razor
@@ -211,8 +211,6 @@
     {
         return commProjectId switch
         {
-            (int)CommunityProject.PointOfSale => "Point Of Sale",
-            (int)CommunityProject.TCSAV2 => "Academy V2",
             (int)CommunityProject.TCSA => "Academy 2026",
             (int)CommunityProject.KnowTheCity => "Know The City",
         };

--- a/TCSA.V2026/Components/Pages/Dashboard/Community.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Community.razor
@@ -159,9 +159,8 @@
         try
         {
             var options = new DialogOptions { CloseOnEscapeKey = true };
-            var parameters = new DialogParameters<TCSASubmitIssueDialog>{ { x => x.UserId, UserId } };
 
-            var dialog = await DialogService.ShowAsync<TCSASubmitIssueDialog>("Submit Issue", parameters, options);
+            var dialog = await DialogService.ShowAsync<TCSASubmitIssueDialog>("Submit Issue", options);
             var result = await dialog.Result;
 
             if (!result.Canceled)

--- a/TCSA.V2026/Components/Pages/Dashboard/Community.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Community.razor
@@ -75,7 +75,7 @@
                                     Size="@Size.Small"
                                     Variant="@Variant.Filled" Color="@Color.Primary"
                                     Disabled="@_isProcessing"
-                                    OnClick="@(() => SubmitToReviewDialog(context.Item.ProjectId))"
+                                    OnClick="@(() => SubmitToReviewDialog(context.Item))"
                                     EndIcon="@Icons.Material.Filled.Send">
                                         Submit PR
                                     </MudButton>
@@ -128,15 +128,20 @@
         IsLoading = false;
     }
 
-    private async Task SubmitToReviewDialog(int projectId)
+    private async Task SubmitToReviewDialog(CommunityIssue issue)
     {
         _isProcessing = true;
 
         try
         {
             var options = new DialogOptions { CloseOnEscapeKey = true };
-            var parameters = new DialogParameters<TCSASubmitProjectDialog> { { x => x.ProjectId, projectId }, { x => x.IsIssue, true }, { x => x.User, User} };
-            var dialog = await DialogService.ShowAsync<TCSASubmitProjectDialog>("Submit Issue", parameters, options);
+            var parameters = new DialogParameters<TCSASubmitIssueToReviewDialog>
+            {
+                { x => x.ProjectId, issue.ProjectId },
+                { x => x.CommunityProject, (CommunityProject)issue.CommunityProjectId },
+                { x => x.CurrentGithubUrl, User.DashboardProjects.FirstOrDefault(d => d.ProjectId == issue.ProjectId)?.GithubUrl ?? string.Empty }
+            };
+            var dialog = await DialogService.ShowAsync<TCSASubmitIssueToReviewDialog>("Submit Issue", parameters, options);
             var result = await dialog.Result;
 
             if (!result.Canceled)

--- a/TCSA.V2026/Components/Pages/Dashboard/Community.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Community.razor
@@ -2,6 +2,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using System.Security.Claims
 @using TCSA.V2026.Data.Curriculum
+@using TCSA.V2026.Data.Enums
 @using TCSA.V2026.Data.Models
 @using TCSA.V2026.Data.Models.Responses
 @using TCSA.V2026.Components.UI
@@ -206,9 +207,10 @@
     {
         return commProjectId switch
         {
-            54 => "Point Of Sale",
-            87 => "Academy V2",
-            207 => "Academy 2026"
+            (int)CommunityProject.PointOfSale => "Point Of Sale",
+            (int)CommunityProject.TCSAV2 => "Academy V2",
+            (int)CommunityProject.TCSA => "Academy 2026",
+            (int)CommunityProject.KnowTheCity => "Know The City",
         };
     }
 }

--- a/TCSA.V2026/Components/UI/TCSASubmitIssueDialog.razor
+++ b/TCSA.V2026/Components/UI/TCSASubmitIssueDialog.razor
@@ -35,7 +35,6 @@
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; }
     [Parameter] public int ProjectId { get; set; }
     [Parameter] public bool IsIssue { get; set; }
-    [Parameter] public string UserId { get; set; }
 
     public string IssueUrl = string.Empty;
     public string IssueTitle = string.Empty;

--- a/TCSA.V2026/Components/UI/TCSASubmitIssueDialog.razor
+++ b/TCSA.V2026/Components/UI/TCSASubmitIssueDialog.razor
@@ -1,4 +1,5 @@
-﻿@using TCSA.V2026.Data.Models
+@using TCSA.V2026.Data.Enums
+@using TCSA.V2026.Data.Models
 @using TCSA.V2026.Data.Models.Responses
 @using TCSA.V2026.Services
 <MudDialog Style="min-width: 400px;">
@@ -16,7 +17,15 @@
             }
 
         </MudSelect>
+        <MudSelect T="CommunityProject" Label="Select Open Source Project" @bind-Value="CommunityProject" Class="my-2" Dense="true" Required>
+            @foreach (CommunityProject project in Enum.GetValues(typeof(CommunityProject)))
+            {
+                <MudSelectItem T="CommunityProject" Value="@project">@project</MudSelectItem>
+            }
+        </MudSelect>
         <MudTextField @bind-Value="IssueUrl"
+                      Error="@HasError"
+                      ErrorText="@ErrorText"
                       Required="true"
                       Label="Issue Url" />
         <MudTextField @bind-Value="IssueTitle"
@@ -35,10 +44,11 @@
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; }
     [Parameter] public int ProjectId { get; set; }
     [Parameter] public bool IsIssue { get; set; }
-
+    
     public string IssueUrl = string.Empty;
     public string IssueTitle = string.Empty;
     public IssueType IssueType = IssueType.Bugfix;
+    public CommunityProject CommunityProject = CommunityProject.TCSA;
     private string ErrorText;
     private bool HasError;
     private bool _isSubmitting = false;
@@ -49,7 +59,15 @@
 
         try
         {
-            var result = await CommunityService.CreateIssue(IssueType, IssueUrl, IssueTitle, UserId);
+            var result = await CommunityService.CreateIssue(IssueType, IssueUrl, IssueTitle, CommunityProject);
+            
+            if (result.Status == ResponseStatus.Fail)
+            {
+                HasError = true;
+                ErrorText = result.Message;
+                return;
+            }
+            
             MudDialog.Close(DialogResult.Ok(result.Status));
         }
         finally

--- a/TCSA.V2026/Components/UI/TCSASubmitIssueDialog.razor
+++ b/TCSA.V2026/Components/UI/TCSASubmitIssueDialog.razor
@@ -42,8 +42,6 @@
     [Inject] protected ICommunityService CommunityService { get; set; }
     [Inject] protected IProjectService ProjectService { get; set; }
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; }
-    [Parameter] public int ProjectId { get; set; }
-    [Parameter] public bool IsIssue { get; set; }
     
     public string IssueUrl = string.Empty;
     public string IssueTitle = string.Empty;

--- a/TCSA.V2026/Components/UI/TCSASubmitIssueToReviewDialog.razor
+++ b/TCSA.V2026/Components/UI/TCSASubmitIssueToReviewDialog.razor
@@ -1,0 +1,93 @@
+@using TCSA.V2026.Data.Enums
+@using TCSA.V2026.Data.Models
+@using TCSA.V2026.Data.Models.Responses
+@using TCSA.V2026.Helpers
+@using TCSA.V2026.Services
+<MudDialog Style="min-width: 400px;">
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.Send" Class="mr-3 mb-n1" />
+            @MudDialog.Title
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudTextField
+        @bind-Value="GithubUrl"
+        Error="@HasError"
+        ErrorText="@ErrorText"
+        Immediate="true"
+        OnBlur="ValidateUrl"
+        Label="GitHub PR URL" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Disabled="@(HasError || _isSubmitting)" Color="Color.Error" OnClick="Submit">Submit</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [Inject] protected ICommunityService CommunityService { get; set; }
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; }
+    [Parameter] public int ProjectId { get; set; }
+    [Parameter] public CommunityProject CommunityProject { get; set; }
+    [Parameter] public string CurrentGithubUrl { get; set; } = string.Empty;
+
+    private string GithubUrl = string.Empty;
+    private string ErrorText = string.Empty;
+    private bool HasError;
+    private bool _isSubmitting = false;
+
+    protected override void OnInitialized()
+    {
+        GithubUrl = CurrentGithubUrl;
+    }
+
+    private void ValidateUrl()
+    {
+        if (string.IsNullOrWhiteSpace(GithubUrl))
+        {
+            HasError = true;
+            ErrorText = "URL is required.";
+            return;
+        }
+
+        if (Enum.IsDefined(typeof(CommunityProject), CommunityProject))
+        {
+            if (!UrlHelper.IsValidCommunityProjectPrUrl(GithubUrl, CommunityProject))
+            {
+                HasError = true;
+                ErrorText = "URL must be a valid pull request URL for this project.";
+                return;
+            }
+        } else
+        {
+            HasError = true;
+            ErrorText = "Invalid project.";
+            return;
+        }
+
+        HasError = false;
+        ErrorText = string.Empty;
+    }
+
+    private async Task Submit()
+    {
+        ValidateUrl();
+        if (HasError)
+            return;
+
+        _isSubmitting = true;
+
+        try
+        {
+            var result = await CommunityService.SubmitIssueToReview(ProjectId, GithubUrl);
+            MudDialog.Close(DialogResult.Ok(result.Status));
+        }
+        finally
+        {
+            _isSubmitting = false;
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/TCSA.V2026/Components/UI/TCSASubmitProjectDialog.razor
+++ b/TCSA.V2026/Components/UI/TCSASubmitProjectDialog.razor
@@ -31,7 +31,6 @@
     [Inject] protected IProjectService ProjectService { get; set; }
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; }
     [Parameter] public int ProjectId { get; set; }
-    [Parameter] public bool IsIssue { get; set; }
     [Parameter] public bool IsUpdate { get; set; }
     [Parameter] public ApplicationUser User { get; set; }
 
@@ -65,7 +64,7 @@
             HasError = true;
             ErrorText = "URL is required.";
         }
-        else if (!IsIssue && !GithubUrl.StartsWith(RequiredPrefix, StringComparison.OrdinalIgnoreCase))
+        else if (!GithubUrl.StartsWith(RequiredPrefix, StringComparison.OrdinalIgnoreCase))
         {
             var errorText = ProjectId == 75 ? $"URL must start with '{RequiredPrefix}'. We need to see your certificate." : $"URL must start with '{RequiredPrefix}'. Read the article above to submit a pull request.";
 
@@ -89,16 +88,7 @@
 
         try
         {
-            var result = new BaseResponse();
-            if (IsIssue)
-            {
-                result = await CommunityService.SubmitIssueToReview(ProjectId, GithubUrl);
-            }
-            else
-            {
-                result = await ProjectService.PostArticle(ProjectId, User.Id, GithubUrl, false, IsUpdate);
-            }
-
+            var result = await ProjectService.PostArticle(ProjectId, User.Id, GithubUrl, false, IsUpdate);
             MudDialog.Close(DialogResult.Ok(result.Status));
         }
         finally

--- a/TCSA.V2026/Data/Enums/CommunityProject.cs
+++ b/TCSA.V2026/Data/Enums/CommunityProject.cs
@@ -2,8 +2,6 @@ namespace TCSA.V2026.Data.Enums;
 
 public enum CommunityProject
 {
-    PointOfSale = 54,
-    TCSAV2 = 87,
     TCSA = 207,
     KnowTheCity = 208,
 }

--- a/TCSA.V2026/Data/Enums/CommunityProject.cs
+++ b/TCSA.V2026/Data/Enums/CommunityProject.cs
@@ -1,0 +1,9 @@
+namespace TCSA.V2026.Data.Enums;
+
+public enum CommunityProject
+{
+    PointOfSale = 54,
+    TCSAV2 = 87,
+    TCSA = 207,
+    KnowTheCity = 208,
+}

--- a/TCSA.V2026/Helpers/Constants/UrlConstants.cs
+++ b/TCSA.V2026/Helpers/Constants/UrlConstants.cs
@@ -1,0 +1,14 @@
+namespace TCSA.V2026.Helpers.Constants;
+
+public static class UrlConstants
+{
+    public const string TCSAGithubBaseUrl = "https://github.com/the-csharp-academy";
+
+    public const string TCSARepositoryBaseUrl = $"{TCSAGithubBaseUrl}/TCSA.V2026";
+    public const string TCSARepositoryIssuesUrl = $"{TCSARepositoryBaseUrl}/issues";
+    public const string TCSARepositoryPullUrl = $"{TCSARepositoryBaseUrl}/pull";
+
+    public const string KnowTheCityRepositoryBaseUrl = $"{TCSAGithubBaseUrl}/TCSA.KnowTheCity";
+    public const string KnowTheCityRepositoryIssuesUrl = $"{KnowTheCityRepositoryBaseUrl}/issues";
+    public const string KnowTheCityRepositoryPullUrl = $"{KnowTheCityRepositoryBaseUrl}/pull";
+}

--- a/TCSA.V2026/Helpers/UrlHelper.cs
+++ b/TCSA.V2026/Helpers/UrlHelper.cs
@@ -1,0 +1,42 @@
+using System.Text.RegularExpressions;
+using TCSA.V2026.Data.Enums;
+using TCSA.V2026.Helpers.Constants;
+
+namespace TCSA.V2026.Helpers;
+
+public static class UrlHelper
+{
+    public static bool IsValidCommunityProjectIssueUrl(string url, CommunityProject communityProject)
+    {
+        var communityProjectRepositoryIssuesUrl = communityProject switch
+        {
+            CommunityProject.TCSA => UrlConstants.TCSARepositoryIssuesUrl,
+            CommunityProject.KnowTheCity => UrlConstants.KnowTheCityRepositoryIssuesUrl,
+            _ => throw new ArgumentException("Invalid community project.")
+        };
+
+        var escapedCommunityProjectRepositoryIssuesUrl = Regex.Escape(communityProjectRepositoryIssuesUrl);
+
+        return Regex.IsMatch(
+            url,
+            $@"^{escapedCommunityProjectRepositoryIssuesUrl}/\d+$",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+
+    public static bool IsValidCommunityProjectPrUrl(string url, CommunityProject communityProject)
+    {
+        var communityProjectRepositoryPullUrl = communityProject switch
+        {
+            CommunityProject.TCSA => UrlConstants.TCSARepositoryPullUrl,
+            CommunityProject.KnowTheCity => UrlConstants.KnowTheCityRepositoryPullUrl,
+            _ => throw new ArgumentException("Invalid community project.")
+        };
+
+        var escapedCommunityProjectRepositoryPullUrl = Regex.Escape(communityProjectRepositoryPullUrl);
+
+        return Regex.IsMatch(
+            url,
+            $@"^{escapedCommunityProjectRepositoryPullUrl}/\d+$",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+}

--- a/TCSA.V2026/Services/CommunityService.cs
+++ b/TCSA.V2026/Services/CommunityService.cs
@@ -1,7 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using TCSA.V2026.Data;
+using TCSA.V2026.Data.Enums;
 using TCSA.V2026.Data.Models;
 using TCSA.V2026.Data.Models.Responses;
+using TCSA.V2026.Helpers;
 
 namespace TCSA.V2026.Services;
 
@@ -11,12 +13,12 @@ public interface ICommunityService
     Task<List<CommunityIssue>> GetAvailableIssuesForCommunityPage(string appUserId);
     Task<BaseResponse> AssignUserToIssue(string appUserId, CommunityIssue issue);
     Task<BaseResponse> SubmitIssueToReview(int issueId, string githubUrl);
-    Task<BaseResponse> CreateIssue(IssueType type, string issueUrl, string Title, string userId);
+    Task<BaseResponse> CreateIssue(IssueType type, string issueUrl, string Title, CommunityProject communityProject);
 }
 
 public class CommunityService(IDbContextFactory<ApplicationDbContext> _factory) : ICommunityService
 {
-    public async Task<BaseResponse> CreateIssue(IssueType type, string issueUrl, string title, string userId)
+    public async Task<BaseResponse> CreateIssue(IssueType type, string issueUrl, string title, CommunityProject communityProject)
     {
         string iconUrl = type switch
         {
@@ -25,6 +27,15 @@ public class CommunityService(IDbContextFactory<ApplicationDbContext> _factory) 
             IssueType.Feature => "icons8-feature-64.png",
             IssueType.Infrastructure => "icons8-infrastructure-55.png"
         };
+
+        if (!UrlHelper.IsValidCommunityProjectIssueUrl(issueUrl, communityProject))
+        {
+            return new BaseResponse
+            {
+                Status = ResponseStatus.Fail,
+                Message = "Invalid issue URL for the selected community project."
+            };
+        }
 
         var result = new BaseResponse();
         try
@@ -49,7 +60,7 @@ public class CommunityService(IDbContextFactory<ApplicationDbContext> _factory) 
                     Title = title,
                     Type = type,
                     IsClosed = false,
-                    CommunityProjectId = 207,
+                    CommunityProjectId = (int)communityProject,
                     ExperiencePoints = 20,
                     IconUrl = iconUrl,
                     ProjectId = nextProjectId

--- a/TCSA.V2026/Services/CommunityService.cs
+++ b/TCSA.V2026/Services/CommunityService.cs
@@ -45,7 +45,7 @@ public class CommunityService(IDbContextFactory<ApplicationDbContext> _factory) 
                 var lastIssue = await context.Issues.OrderBy(x => x.ProjectId).LastOrDefaultAsync();
                 int nextProjectId = lastIssue != null ? lastIssue.ProjectId + 1 : 1;
 
-                var existingIssue = await context.Issues.FirstOrDefaultAsync(i => i.GithubUrl == issueUrl);
+                var existingIssue = await context.Issues.FirstOrDefaultAsync(i => i.GithubUrl == issueUrl && i.CommunityProjectId == (int)communityProject);
 
                 if (existingIssue != null)
                 {


### PR DESCRIPTION
## Description

This PR expands community issue support to additional community projects, adds proper URL validation for issue and PR URLs, and simplifies `TCSASubmitProjectDialog` by moving issue related logic into a separate `TCSASubmitIssueToReviewDialog` component.

## Related Issue

<!-- Link the issue this PR resolves. Use "Closes #123" to auto-close it on merge. -->

Closes #429

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / configuration
- [ ] Other: <!-- describe -->

## Implementation Details

- Added the `CommunityProject` enum to store identifiers for supported community projects
- Added a seperate `TCSASubmitIssueToReviewDialog` component and simplified `TCSASubmitProjectDialog`
- Added `UrlHelper` to validate community project issue and PR URLs, preventing XSS attacks and malicious links
- Added `UrlHelperTests` to ensure `UrlHelper` behaves as intented
- Updated `DialogTests` to reflect the simplified Dialog components

## Testing Performed

<!-- Describe how you tested this change. -->

- [x] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [x] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [x] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [x] Added new tests covering the change
- [x] Manually verified in the browser

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have read the related issue and my implementation matches the requirements
- [x] No sensitive data (credentials, secrets) committed
- [x] All new and existing tests pass