### PR TITLE
feat: add platform filter to challenges page

### DIFF
--- a/TCSA.2026.IntegrationTests/ChallengeServiceTests.cs
+++ b/TCSA.2026.IntegrationTests/ChallengeServiceTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using TCSA.V2026.Data.Enums;
+using TCSA.V2026.Data.Models;
 using TCSA.V2026.Services;
 
 namespace TCSA.V2026.IntegrationTests;
@@ -146,63 +148,339 @@ public class ChallengeServiceTests : IntegrationTestsBase
     }
 
     [Test]
-    public async Task GetStreakInfo_ShouldReturnNewStreakInfo_WhenUserHasNoExistingStreak()
+    public async Task GetChallengeStatistics_ShouldReturnNull_WhenUserDoesNotExist()
     {
-        // Arrange
-        string userId = "user1";
-        using (var seedContext = DbContextFactory.CreateDbContext())
-        {
-            var existingStreak = await seedContext.DailyStreaks
-                .FirstOrDefaultAsync(s => s.AppUserId == userId);
-            if (existingStreak != null)
-            {
-                seedContext.DailyStreaks.Remove(existingStreak);
-                await seedContext.SaveChangesAsync();
-            }
-        }
-
         // Act
-        var streakInfo = await _service.GetStreakInfo(userId);
+        var result = await _service.GetChallengeStatistics("nonexistent-user");
 
         // Assert
-        Assert.That(streakInfo, Is.Not.Null);
-        Assert.That(streakInfo.CurrentStreak, Is.EqualTo(0));
-        Assert.That(streakInfo.LongestStreak, Is.EqualTo(0));
-        Assert.That(streakInfo.LastCompletedDate, Is.EqualTo(default(DateTime)));
+        Assert.That(result, Is.Null);
     }
 
     [Test]
-    public async Task GetStreakInfo_ShouldResetStreak_WhenLastCompletedDateIsBeforeYesterday()
+    public async Task GetChallengeStatistics_ShouldReturnZeroCompletedChallenges_WhenUserHasNoCompletedChallenges()
+    {
+        // Act
+        var result = await _service.GetChallengeStatistics("user1");
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.CompletedChallenges, Is.Zero);
+    }
+
+    [Test]
+    public async Task GetChallengeStatistics_ShouldReturnCorrectCompletedChallenges_WhenUserHasCompletedChallenges()
     {
         // Arrange
         string userId = "user1";
         using (var seedContext = DbContextFactory.CreateDbContext())
         {
-            var existingStreak = await seedContext.DailyStreaks
-                .FirstOrDefaultAsync(s => s.AppUserId == userId);
-            if (existingStreak != null)
+            seedContext.Challenges.AddRange(
+                BuildChallenge(1),
+                BuildChallenge(2)
+            );
+            seedContext.UserChallenges.AddRange(
+                new UserChallenge { ChallengeId = 1, UserId = userId, CompletedAt = DateTime.UtcNow.AddDays(-2) },
+                new UserChallenge { ChallengeId = 2, UserId = userId, CompletedAt = DateTime.UtcNow.AddDays(-1) }
+            );
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var result = await _service.GetChallengeStatistics(userId);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.CompletedChallenges, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetChallengeStatistics_ShouldReturnCorrectStreakInfo_WhenStreakIsActive()
+    {
+        // Arrange
+        string userId = "user1";
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            var streak = await seedContext.DailyStreaks.FirstOrDefaultAsync(s => s.AppUserId == userId);
+            if (streak != null)
             {
-                existingStreak.CurrentStreak = 3;
-                existingStreak.LongestStreak = 5;
-                existingStreak.LastCompletedDate = DateTime.UtcNow.Date.AddDays(-3);
-                seedContext.DailyStreaks.Update(existingStreak);
+                streak.CurrentStreak = 5;
+                streak.LongestStreak = 10;
+                streak.LastCompletedDate = DateTime.UtcNow.Date.AddDays(-1);
+                seedContext.DailyStreaks.Update(streak);
                 await seedContext.SaveChangesAsync();
             }
         }
 
         // Act
-        var streakInfo = await _service.GetStreakInfo(userId);
+        var result = await _service.GetChallengeStatistics(userId);
 
         // Assert
-        Assert.That(streakInfo, Is.Not.Null);
-        Assert.That(streakInfo.CurrentStreak, Is.EqualTo(0));
-        Assert.That(streakInfo.LongestStreak, Is.EqualTo(5));
-        Assert.That(streakInfo.LastCompletedDate.Date, Is.EqualTo(DateTime.UtcNow.Date.AddDays(-3)));
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.DailyStreakDetails.CurrentStreak, Is.EqualTo(5));
+        Assert.That(result.DailyStreakDetails.LongestStreak, Is.EqualTo(10));
+        Assert.That(result.DailyStreakDetails.LastCompletedDate.Date, Is.EqualTo(DateTime.UtcNow.Date.AddDays(-1)));
+    }
+
+    [Test]
+    public async Task GetChallengeStatistics_ShouldResetCurrentStreak_WhenStreakHasExpired()
+    {
+        // Arrange
+        string userId = "user1";
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            var streak = await seedContext.DailyStreaks.FirstOrDefaultAsync(s => s.AppUserId == userId);
+            if (streak != null)
+            {
+                streak.CurrentStreak = 3;
+                streak.LongestStreak = 7;
+                streak.LastCompletedDate = DateTime.UtcNow.Date.AddDays(-3);
+                seedContext.DailyStreaks.Update(streak);
+                await seedContext.SaveChangesAsync();
+            }
+        }
+
+        // Act
+        var result = await _service.GetChallengeStatistics(userId);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.DailyStreakDetails.CurrentStreak, Is.EqualTo(0));
+        Assert.That(result.DailyStreakDetails.LongestStreak, Is.EqualTo(7));
 
         using var assertContext = DbContextFactory.CreateDbContext();
-        var updatedStreak = await assertContext.DailyStreaks
-            .FirstOrDefaultAsync(s => s.AppUserId == userId);
+        var updatedStreak = await assertContext.DailyStreaks.FirstOrDefaultAsync(s => s.AppUserId == userId);
         Assert.That(updatedStreak, Is.Not.Null);
-        Assert.That(updatedStreak.CurrentStreak, Is.EqualTo(0));
+        Assert.That(updatedStreak.CurrentStreak, Is.Zero);
+    }
+
+    [Test]
+    public async Task GetChallengeStatistics_ShouldNotResetStreak_WhenLastCompletedDateIsToday()
+    {
+        // Arrange
+        string userId = "user1";
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            var streak = await seedContext.DailyStreaks.FirstOrDefaultAsync(s => s.AppUserId == userId);
+            if (streak != null)
+            {
+                streak.CurrentStreak = 4;
+                streak.LongestStreak = 8;
+                streak.LastCompletedDate = DateTime.UtcNow.Date;
+                seedContext.DailyStreaks.Update(streak);
+                await seedContext.SaveChangesAsync();
+            }
+        }
+
+        // Act
+        var result = await _service.GetChallengeStatistics(userId);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.DailyStreakDetails.CurrentStreak, Is.EqualTo(4));
+    }
+
+    [Test]
+    public async Task GetChallengeStatistics_ShouldNotResetStreak_WhenLastCompletedDateIsYesterday()
+    {
+        // Arrange
+        string userId = "user1";
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            var streak = await seedContext.DailyStreaks.FirstOrDefaultAsync(s => s.AppUserId == userId);
+            if (streak != null)
+            {
+                streak.CurrentStreak = 6;
+                streak.LongestStreak = 6;
+                streak.LastCompletedDate = DateTime.UtcNow.Date.AddDays(-1);
+                seedContext.DailyStreaks.Update(streak);
+                await seedContext.SaveChangesAsync();
+            }
+        }
+
+        // Act
+        var result = await _service.GetChallengeStatistics(userId);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.DailyStreakDetails.CurrentStreak, Is.EqualTo(6));
+    }
+
+    private static Challenge BuildChallenge(
+        int id,
+        Level level = Level.White,
+        ChallengeCategory category = ChallengeCategory.CSharp,
+        ChallengePlatform platform = ChallengePlatform.CodeWars,
+        int daysOffset = -1) =>
+        new Challenge
+        {
+            Id = id,
+            ExternalId = $"ext{id}",
+            Name = $"Challenge {id}",
+            Description = "desc",
+            Keywords = "kw",
+            ReleaseDate = DateTime.UtcNow.AddDays(daysOffset),
+            ExperiencePoints = 10 * id,
+            Platform = platform,
+            Category = category,
+            Level = level
+        };
+
+    [Test]
+    public async Task GetPaginatedChallenges_ShouldReturnEmpty_WhenNoChallengesExist()
+    {
+        // Act
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.White, false, [], []);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Items, Is.Empty);
+        Assert.That(result.TotalPages, Is.Zero);
+    }
+
+    [Test]
+    public async Task GetPaginatedChallenges_ShouldOnlyReturnChallengesUpToOneLevelAboveUser()
+    {
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.Challenges.Add(BuildChallenge(1, level: Level.White));
+            seedContext.Challenges.Add(BuildChallenge(2, level: Level.Green));
+            seedContext.Challenges.Add(BuildChallenge(3, level: Level.OliveGreen));
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.White, false, [], []);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Items.Count, Is.EqualTo(2));
+        Assert.That(result.Items.Select(c => c.Id), Is.EquivalentTo([1, 2]));
+    }
+
+    [Test]
+    public async Task GetPaginatedChallenges_WithShowCompletedFalse_ShouldExcludeCompletedChallenges()
+    {
+        // Arrange
+        string userId = "user1";
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.Challenges.Add(BuildChallenge(1));
+            seedContext.Challenges.Add(BuildChallenge(2));
+            seedContext.UserChallenges.Add(new UserChallenge { ChallengeId = 1, UserId = userId, CompletedAt = DateTime.UtcNow.AddDays(-1) });
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var result = await _service.GetPaginatedChallenges(1, userId, Level.White, showCompleted: false, [], []);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Items.Count, Is.EqualTo(1));
+        Assert.That(result.Items[0].Id, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetPaginatedChallenges_WithShowCompletedTrue_ShouldIncludeCompletedChallenges()
+    {
+        // Arrange
+        string userId = "user1";
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.Challenges.Add(BuildChallenge(1));
+            seedContext.Challenges.Add(BuildChallenge(2));
+            seedContext.UserChallenges.Add(new UserChallenge { ChallengeId = 1, UserId = userId, CompletedAt = DateTime.UtcNow.AddDays(-1) });
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var result = await _service.GetPaginatedChallenges(1, userId, Level.White, showCompleted: true, [], []);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Items.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetPaginatedChallenges_WithLevelFilter_ShouldReturnOnlyMatchingLevels()
+    {
+        // Arrange
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.Challenges.Add(BuildChallenge(1, level: Level.White));
+            seedContext.Challenges.Add(BuildChallenge(2, level: Level.Green));
+            seedContext.Challenges.Add(BuildChallenge(3, level: Level.OliveGreen));
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.Green, false, [Level.White], []);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Items.Count, Is.EqualTo(1));
+        Assert.That(result.Items[0].Level, Is.EqualTo(Level.White));
+    }
+
+    [Test]
+    public async Task GetPaginatedChallenges_WithMultipleSelectedLevels_ShouldReturnAllMatchingLevels()
+    {
+        // Arrange
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.Challenges.Add(BuildChallenge(1, level: Level.White));
+            seedContext.Challenges.Add(BuildChallenge(2, level: Level.Green));
+            seedContext.Challenges.Add(BuildChallenge(3, level: Level.OliveGreen));
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.OliveGreen, false, [Level.White, Level.Green], []);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Items.Count, Is.EqualTo(2));
+        Assert.That(result.Items.Select(c => c.Id), Is.EquivalentTo([1, 2]));
+    }
+
+    [Test]
+    public async Task GetPaginatedChallenges_WithCategoryFilter_ShouldReturnOnlyMatchingCategories()
+    {
+        // Arrange
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.Challenges.Add(BuildChallenge(1, category: ChallengeCategory.CSharp));
+            seedContext.Challenges.Add(BuildChallenge(2, category: ChallengeCategory.SQL));
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.White, false, [], [ChallengeCategory.SQL]);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Items.Count, Is.EqualTo(1));
+        Assert.That(result.Items[0].Category, Is.EqualTo(ChallengeCategory.SQL));
+    }
+
+    [Test]
+    public async Task GetPaginatedChallenges_WithLevelAndCategoryFilters_ShouldReturnOnlyMatchingChallenges()
+    {
+        // Arrange
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.Challenges.Add(BuildChallenge(1, level: Level.White, category: ChallengeCategory.CSharp));
+            seedContext.Challenges.Add(BuildChallenge(2, level: Level.White, category: ChallengeCategory.SQL));
+            seedContext.Challenges.Add(BuildChallenge(3, level: Level.Green, category: ChallengeCategory.CSharp));
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.Green, false, [Level.White], [ChallengeCategory.CSharp]);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Items.Count, Is.EqualTo(1));
+        Assert.That(result.Items[0].Id, Is.EqualTo(1));
     }
 }

--- a/TCSA.2026.IntegrationTests/ChallengeServiceTests.cs
+++ b/TCSA.2026.IntegrationTests/ChallengeServiceTests.cs
@@ -330,7 +330,7 @@ public class ChallengeServiceTests : IntegrationTestsBase
     public async Task GetPaginatedChallenges_ShouldReturnEmpty_WhenNoChallengesExist()
     {
         // Act
-        var result = await _service.GetPaginatedChallenges(1, "user1", Level.White, false, [], []);
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.White, false, [], [], []);
 
         // Assert
         Assert.That(result, Is.Not.Null);
@@ -350,7 +350,7 @@ public class ChallengeServiceTests : IntegrationTestsBase
         }
 
         // Act
-        var result = await _service.GetPaginatedChallenges(1, "user1", Level.White, false, [], []);
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.White, false, [], [], []);
 
         // Assert
         Assert.That(result, Is.Not.Null);
@@ -372,7 +372,7 @@ public class ChallengeServiceTests : IntegrationTestsBase
         }
 
         // Act
-        var result = await _service.GetPaginatedChallenges(1, userId, Level.White, showCompleted: false, [], []);
+        var result = await _service.GetPaginatedChallenges(1, userId, Level.White, showCompleted: false, [], [], []);
 
         // Assert
         Assert.That(result, Is.Not.Null);
@@ -394,7 +394,7 @@ public class ChallengeServiceTests : IntegrationTestsBase
         }
 
         // Act
-        var result = await _service.GetPaginatedChallenges(1, userId, Level.White, showCompleted: true, [], []);
+        var result = await _service.GetPaginatedChallenges(1, userId, Level.White, showCompleted: true, [], [], []);
 
         // Assert
         Assert.That(result, Is.Not.Null);
@@ -414,7 +414,7 @@ public class ChallengeServiceTests : IntegrationTestsBase
         }
 
         // Act
-        var result = await _service.GetPaginatedChallenges(1, "user1", Level.Green, false, [Level.White], []);
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.Green, false, [Level.White], [], []);
 
         // Assert
         Assert.That(result, Is.Not.Null);
@@ -435,7 +435,7 @@ public class ChallengeServiceTests : IntegrationTestsBase
         }
 
         // Act
-        var result = await _service.GetPaginatedChallenges(1, "user1", Level.OliveGreen, false, [Level.White, Level.Green], []);
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.OliveGreen, false, [Level.White, Level.Green], [], []);
 
         // Assert
         Assert.That(result, Is.Not.Null);
@@ -455,7 +455,7 @@ public class ChallengeServiceTests : IntegrationTestsBase
         }
 
         // Act
-        var result = await _service.GetPaginatedChallenges(1, "user1", Level.White, false, [], [ChallengeCategory.SQL]);
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.White, false, [], [ChallengeCategory.SQL], []);
 
         // Assert
         Assert.That(result, Is.Not.Null);
@@ -476,7 +476,71 @@ public class ChallengeServiceTests : IntegrationTestsBase
         }
 
         // Act
-        var result = await _service.GetPaginatedChallenges(1, "user1", Level.Green, false, [Level.White], [ChallengeCategory.CSharp]);
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.Green, false, [Level.White], [ChallengeCategory.CSharp], []);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Items.Count, Is.EqualTo(1));
+        Assert.That(result.Items[0].Id, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GetPaginatedChallenges_WithPlatformFilter_ShouldReturnOnlyMatchingPlatform()
+    {
+        // Arrange
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.Challenges.Add(BuildChallenge(1, platform: ChallengePlatform.CodeWars));
+            seedContext.Challenges.Add(BuildChallenge(2, platform: ChallengePlatform.LeetCode));
+            seedContext.Challenges.Add(BuildChallenge(3, platform: ChallengePlatform.HackerRank));
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.White, false, [], [], [ChallengePlatform.LeetCode]);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Items.Count, Is.EqualTo(1));
+        Assert.That(result.Items[0].Platform, Is.EqualTo(ChallengePlatform.LeetCode));
+    }
+
+    [Test]
+    public async Task GetPaginatedChallenges_WithMultipleSelectedPlatforms_ShouldReturnAllMatchingPlatforms()
+    {
+        // Arrange
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.Challenges.Add(BuildChallenge(1, platform: ChallengePlatform.CodeWars));
+            seedContext.Challenges.Add(BuildChallenge(2, platform: ChallengePlatform.LeetCode));
+            seedContext.Challenges.Add(BuildChallenge(3, platform: ChallengePlatform.HackerRank));
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.White, false, [], [], [ChallengePlatform.CodeWars, ChallengePlatform.LeetCode]);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Items.Count, Is.EqualTo(2));
+        Assert.That(result.Items.Select(c => c.Id), Is.EquivalentTo([1, 2]));
+    }
+
+    [Test]
+    public async Task GetPaginatedChallenges_WithAllFilters_ShouldReturnOnlyMatchingChallenges()
+    {
+        // Arrange
+        using (var seedContext = DbContextFactory.CreateDbContext())
+        {
+            seedContext.Challenges.Add(BuildChallenge(1, level: Level.White, category: ChallengeCategory.CSharp, platform: ChallengePlatform.LeetCode));
+            seedContext.Challenges.Add(BuildChallenge(2, level: Level.White, category: ChallengeCategory.SQL, platform: ChallengePlatform.LeetCode));
+            seedContext.Challenges.Add(BuildChallenge(3, level: Level.White, category: ChallengeCategory.CSharp, platform: ChallengePlatform.CodeWars));
+            seedContext.Challenges.Add(BuildChallenge(4, level: Level.Green, category: ChallengeCategory.CSharp, platform: ChallengePlatform.LeetCode));
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var result = await _service.GetPaginatedChallenges(1, "user1", Level.Green, false, [Level.White], [ChallengeCategory.CSharp], [ChallengePlatform.LeetCode]);
 
         // Assert
         Assert.That(result, Is.Not.Null);

--- a/TCSA.2026.IntegrationTests/CodeWarsServiceTests.cs
+++ b/TCSA.2026.IntegrationTests/CodeWarsServiceTests.cs
@@ -1,5 +1,5 @@
 using Moq;
-using TCSA.V2026.Data.DTOs;
+using TCSA.V2026.Data.DTOs.Challenges;
 using TCSA.V2026.Data.Enums;
 using TCSA.V2026.Data.Models;
 using TCSA.V2026.Services.Challenges;

--- a/TCSA.2026.IntegrationTests/LeetCodeServiceTests.cs
+++ b/TCSA.2026.IntegrationTests/LeetCodeServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using TCSA.V2026.Data.DTOs;
+using TCSA.V2026.Data.DTOs.Challenges;
 using TCSA.V2026.Data.Enums;
 using TCSA.V2026.Data.Models;
 using TCSA.V2026.Data.Models.Responses;

--- a/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
@@ -25,7 +25,7 @@
                 <MudText Typo="Typo.subtitle1" Style="font-weight: bold; color: white;">COMPLETED</MudText>
             </MudStack>
             <MudStack Spacing="0" AlignItems="AlignItems.Center" Class="px-4 px-md-5">
-                <MudText Style="font-size: 2.5rem; font-weight: bolder;">@CompletedChallenges.Count</MudText>
+                <MudText Style="font-size: 2.5rem; font-weight: bolder;">@ChallengeStatistics?.CompletedChallenges</MudText>
                 <MudText Style="font-size: 1.25rem;">Challenges</MudText>
             </MudStack>
         </MudPaper>
@@ -35,9 +35,9 @@
                 <MudText Typo="Typo.subtitle1" Style="font-weight: bold; color: white;">STREAK</MudText>
             </MudStack>
             <MudStack Spacing="0" AlignItems="AlignItems.Center" Class="px-4 px-md-5">
-                <MudText Style="font-size: 2.5rem; font-weight: bolder;">@UserStreak.CurrentStreak</MudText>
+                <MudText Style="font-size: 2.5rem; font-weight: bolder;">@ChallengeStatistics?.DailyStreakDetails.CurrentStreak</MudText>
                 <MudText Style="font-size: 1.25rem;">Days</MudText>
-                <MudText Typo="Typo.caption">Best: @UserStreak.LongestStreak days</MudText>
+                <MudText Typo="Typo.caption">Best: @ChallengeStatistics?.DailyStreakDetails.LongestStreak days</MudText>
             </MudStack>
         </MudPaper>
     </MudStack>
@@ -245,8 +245,7 @@
         UserId = claims.FindFirstValue(ClaimTypes.NameIdentifier);
         User = await UserService.GetUserProfileById(UserId);
         ChallengesList = await ChallengeService.GetChallenges(User.Level);
-        CompletedChallenges = User.UserChallenges.Select(uc => uc.ChallengeId).ToList();
-        UserStreak = await ChallengeService.GetStreakInfo(UserId);
+        ChallengeStatistics = await ChallengeService.GetChallengeStatistics(UserId);
 
         LoadTime = DateTime.UtcNow - startTime;
 
@@ -326,7 +325,7 @@
             Snackbar.Add("Sync Successful", Severity.Success);
 
             await ChallengeService.UpdateStreakInfo(UserId);
-            UserStreak = await ChallengeService.GetStreakInfo(UserId);
+            ChallengeStatistics = await ChallengeService.GetChallengeStatistics(UserId);
             User = await UserService.GetUserChallengeDetails(UserId);
             CompletedChallenges = User.UserChallenges.Select(uc => uc.ChallengeId).ToList();
         }

--- a/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
@@ -2,6 +2,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using System.Security.Claims
 @using TCSA.V2026.Data.DTOs
+@using TCSA.V2026.Data.DTOs.Challenges
 @using TCSA.V2026.Data.Enums
 @using TCSA.V2026.Data.Models
 @using TCSA.V2026.Data.Models.Responses
@@ -49,45 +50,48 @@
     else
     {
         @*  <MudText>LoadTime: @LoadTime.TotalSeconds.ToString()</MudText> *@
-        if (ChallengesList != null && ChallengesList.Count > 0)
-        {
-            <MudStack Row Class="mt-6 mb-4" Spacing="4" AlignItems="AlignItems.Center" Breakpoint="Breakpoint.Xs">                
-                <MudCheckBox @bind-Value="@ShowCompleted"
-                Label="Show Completed"
-                CheckedIcon="@Icons.Material.Outlined.CheckBox"
-                UncheckedIcon="@Icons.Material.Outlined.CheckBoxOutlineBlank" />
-                <MudStack Row Spacing="4">
-                    <MudSelect T="Level"
-                    Label="Filter by Level"
-                    Placeholder="Level"
-                    Class="flex-grow-0"
-                    MultiSelection="true"                
-                    @bind-SelectedValues="SelectedLevels">
-                        @foreach (Level item in Enum.GetValues(typeof(Level)))
+        <MudStack Row Class="mt-6 mb-4" Spacing="4" AlignItems="AlignItems.Center" Breakpoint="Breakpoint.Xs">
+            <MudCheckBox @bind-Value="@ShowCompleted"
+                         @bind-Value:after="HandleShowCompletedChanged"
+                         Label="Show Completed"
+                         CheckedIcon="@Icons.Material.Outlined.CheckBox"
+                         UncheckedIcon="@Icons.Material.Outlined.CheckBoxOutlineBlank" />
+            <MudStack Row Spacing="4">
+                <MudSelect T="Level"
+                           Label="Filter by Level"
+                           Placeholder="Level"
+                           Class="flex-grow-0"
+                           MultiSelection="true"
+                           SelectedValues="SelectedLevels"
+                           SelectedValuesChanged="@((IEnumerable<Level> values) => HandleLevelSelection(values))">
+                    @foreach (Level item in Enum.GetValues(typeof(Level)))
+                    {
+                        <MudSelectItem Value="@item">@item.ToString()</MudSelectItem>
+                    }
+                </MudSelect>
+                <MudSelect T="ChallengeCategory"
+                           Label="Filter by Category"
+                           Placeholder="Category"
+                           Class="flex-grow-0"
+                           MultiSelection="true"
+                           SelectedValues="SelectedCategories"
+                           SelectedValuesChanged="@((IEnumerable<ChallengeCategory> values) => HandleCategorySelection(values))">
+                    @foreach (ChallengeCategory item in Enum.GetValues(typeof(ChallengeCategory)))
+                    {
+                        if (item != ChallengeCategory.Unknown)
                         {
                             <MudSelectItem Value="@item">@item.ToString()</MudSelectItem>
                         }
-                    </MudSelect>
-                    <MudSelect T="ChallengeCategory"
-                    Label="Filter by Category"
-                    Placeholder="Category"
-                    Class="flex-grow-0"
-                    MultiSelection="true"
-                    @bind-SelectedValues="SelectedCategories">
-                        @foreach (ChallengeCategory item in Enum.GetValues(typeof(ChallengeCategory)))
-                        {
-                            if(item != ChallengeCategory.Unknown)
-                            {
-                                <MudSelectItem Value="@item">@item.ToString()</MudSelectItem>
-                            }
-                        }
-                    </MudSelect>
-                </MudStack>
+                    }
+                </MudSelect>
             </MudStack>
-            <MudStack Spacing="4">
-                @foreach (var challenge in PaginatedChallenges)
+        </MudStack>
+        if (PaginatedChallenges != null && PaginatedChallenges.Items.Count > 0)
+        {
+            <MudStack Spacing="4" Class="mb-4">
+                @foreach (var challenge in PaginatedChallenges.Items)
                 {
-                    <MudPaper Elevation="3" Outlined="false" Class="py-2 px-2 px-sm-5" Style="@(CompletedChallenges.Contains(challenge.Id) ? "border: 2px solid green;" : "")">
+                    <MudPaper Elevation="3" Outlined="false" Class="py-2 px-2 px-sm-5" Style="@(challenge.IsCompleted ? "border: 2px solid green;" : "")">
                         <MudStack Row Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
                             <MudStack Row Spacing="5">
                                 <MudImage ObjectFit="ObjectFit.Contain" Width="60" Src="@($"img/belts/{challenge.Level}-belt.png")" />
@@ -113,7 +117,7 @@
                                 StartIcon="fas fa-eye">
                                     View
                                 </MudButton>
-                                @if (!CompletedChallenges.Contains(challenge.Id))
+                                @if (!challenge.IsCompleted)
                                 {
                                     <MudButton Size="@Size.Small"
                                     Variant="@Variant.Filled"
@@ -142,22 +146,27 @@
                     </MudPaper>
                 }
             </MudStack>
-            @if (Pages > 1) {
+            @if (PaginatedChallenges.TotalPages > 1) {
                 <MudBreakpointProvider OnBreakpointChanged="BreakpointChanged">
                     <MudPagination Class="mt-3 justify-center"
                     Style="width: 100%;"
-                    Count="Pages"
+                    Count="PaginatedChallenges.TotalPages"
                     Selected="CurrentPage"
-                    SelectedChanged="OnPageChanged"
+                    SelectedChanged="OnPageChangedAsync"
                     BoundaryCount="_boundaryCount"
                     Size="_paginationSize" />
                 </MudBreakpointProvider>
             }
+        } else
+        {
+            <MudText Typo="Typo.h4" Align="Align.Center">
+                No challenges match your search.
+            </MudText>
         }
     }
 </MudContainer>
 
-@code {
+    @code {
     [Inject] private NavigationManager Navigation { get; set; }
     [Inject] private AuthenticationStateProvider AuthenticationState { get; set; }
     [Inject] private IChallengeService ChallengeService { get; set; }
@@ -167,57 +176,15 @@
     [Inject] private IJSRuntime JS { get; set; }
     [Inject] private ISnackbar Snackbar { get; set; }
 
-    private List<Challenge> ChallengesList = new();
-    private DailyStreak UserStreak = new();
-    private List<int> CompletedChallenges = new();
+    private ChallengeStatistics? ChallengeStatistics;
     private ApplicationUser User { get; set; }
-    private List<Challenge> FilteredChallenges =>
-        ChallengesList.Where(c =>
-            (!_showCompleted || IsCompleted(c.Id)) &&
-            (!_selectedLevels.Any() || _selectedLevels.Contains(c.Level)) &&
-            (!_selectedCategories.Any() || _selectedCategories.Contains(c.Category))
-        )
-        .ToList();
 
-    private List<Challenge> PaginatedChallenges => FilteredChallenges
-        .Skip((CurrentPage - 1) * PagingConstants.ChallengesPageSize)
-        .Take(PagingConstants.ChallengesPageSize)
-        .ToList();
-
-    private int Pages => (int)Math.Ceiling((double)TotalFilteredChallenges / PagingConstants.ChallengesPageSize);
     private int CurrentPage = 1;
-    private int TotalFilteredChallenges => FilteredChallenges.Count;
+    private PaginatedList<ChallengeDetails>? PaginatedChallenges;
 
-    private IEnumerable<Level> _selectedLevels = new HashSet<Level>();
-    private IEnumerable<Level> SelectedLevels
-    {
-        get => _selectedLevels;
-        set
-        {
-            _selectedLevels = value;
-            CurrentPage = 1;
-        }
-    }
-    private IEnumerable<ChallengeCategory> _selectedCategories = new HashSet<ChallengeCategory>();
-    private IEnumerable<ChallengeCategory> SelectedCategories
-    {
-        get => _selectedCategories;
-        set
-        {
-            _selectedCategories = value;
-            CurrentPage = 1;
-        }
-    }
-    private bool _showCompleted = false;
-    private bool ShowCompleted
-    {
-        get => _showCompleted;
-        set
-        {
-            _showCompleted = value;
-            CurrentPage = 1;
-        }
-    }
+    private IEnumerable<Level> SelectedLevels = [];
+    private IEnumerable<ChallengeCategory> SelectedCategories = [];
+    private bool ShowCompleted = false;
 
     private HashSet<int> ProcessingChallenges = new();
     private Dictionary<int, DateTime> ChallengeCooldowns = new();
@@ -244,7 +211,7 @@
         var claims = authSate.User;
         UserId = claims.FindFirstValue(ClaimTypes.NameIdentifier);
         User = await UserService.GetUserProfileById(UserId);
-        ChallengesList = await ChallengeService.GetChallenges(User.Level);
+        await GetChallenges();
         ChallengeStatistics = await ChallengeService.GetChallengeStatistics(UserId);
 
         LoadTime = DateTime.UtcNow - startTime;
@@ -284,11 +251,6 @@
         }
     }
 
-    private bool IsCompleted(int id)
-    {
-        return CompletedChallenges.Contains(id);
-    }
-
     private bool IsInCooldown(int challengeId)
     {
         return ChallengeCooldowns.TryGetValue(challengeId, out var until)
@@ -326,8 +288,7 @@
 
             await ChallengeService.UpdateStreakInfo(UserId);
             ChallengeStatistics = await ChallengeService.GetChallengeStatistics(UserId);
-            User = await UserService.GetUserChallengeDetails(UserId);
-            CompletedChallenges = User.UserChallenges.Select(uc => uc.ChallengeId).ToList();
+            await GetChallenges();
         }
         else
         {
@@ -338,9 +299,36 @@
         ProcessingChallenges.Remove(challengeId);
     }
 
-    private void OnPageChanged(int page)
+    private async Task OnPageChangedAsync(int page)
     {
         CurrentPage = page;
+        await GetChallenges();
+    }
+
+    private async Task GetChallenges()
+    {
+        PaginatedChallenges = await ChallengeService.GetPaginatedChallenges(
+           CurrentPage, UserId, User.Level, ShowCompleted, SelectedLevels, SelectedCategories);
+    }
+
+    private async Task HandleLevelSelection(IEnumerable<Level> values)
+    {
+        CurrentPage = 1;
+        SelectedLevels = values;
+        await GetChallenges();
+    }
+
+    private async Task HandleCategorySelection(IEnumerable<ChallengeCategory> values)
+    {
+        CurrentPage = 1;
+        SelectedCategories = values;
+        await GetChallenges();
+    }
+
+    private async Task HandleShowCompletedChanged()
+    {
+        CurrentPage = 1;
+        await GetChallenges();
     }
 
     private void BreakpointChanged(Breakpoint breakpoint)

--- a/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
@@ -243,7 +243,7 @@
 
         var claims = authSate.User;
         UserId = claims.FindFirstValue(ClaimTypes.NameIdentifier);
-        User = await UserService.GetUserChallengeDetails(UserId);
+        User = await UserService.GetUserProfileById(UserId);
         ChallengesList = await ChallengeService.GetChallenges(User.Level);
         CompletedChallenges = User.UserChallenges.Select(uc => uc.ChallengeId).ToList();
         UserStreak = await ChallengeService.GetStreakInfo(UserId);

--- a/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Challenges.razor
@@ -84,6 +84,18 @@
                         }
                     }
                 </MudSelect>
+                <MudSelect T="ChallengePlatform"
+                           Label="Filter by Platform"
+                           Placeholder="Platform"
+                           Class="flex-grow-0"
+                           MultiSelection="true"
+                           SelectedValues="SelectedPlatforms"
+                           SelectedValuesChanged="@((IEnumerable<ChallengePlatform> values) => HandlePlatformSelection(values))">
+                    @foreach (ChallengePlatform item in Enum.GetValues(typeof(ChallengePlatform)))
+                    {
+                        <MudSelectItem Value="@item">@item.ToString()</MudSelectItem>
+                    }
+                </MudSelect>
             </MudStack>
         </MudStack>
         if (PaginatedChallenges != null && PaginatedChallenges.Items.Count > 0)
@@ -184,6 +196,7 @@
 
     private IEnumerable<Level> SelectedLevels = [];
     private IEnumerable<ChallengeCategory> SelectedCategories = [];
+    private IEnumerable<ChallengePlatform> SelectedPlatforms = [];
     private bool ShowCompleted = false;
 
     private HashSet<int> ProcessingChallenges = new();
@@ -308,7 +321,7 @@
     private async Task GetChallenges()
     {
         PaginatedChallenges = await ChallengeService.GetPaginatedChallenges(
-           CurrentPage, UserId, User.Level, ShowCompleted, SelectedLevels, SelectedCategories);
+           CurrentPage, UserId, User.Level, ShowCompleted, SelectedLevels, SelectedCategories, SelectedPlatforms);
     }
 
     private async Task HandleLevelSelection(IEnumerable<Level> values)
@@ -328,6 +341,13 @@
     private async Task HandleShowCompletedChanged()
     {
         CurrentPage = 1;
+        await GetChallenges();
+    }
+
+    private async Task HandlePlatformSelection(IEnumerable<ChallengePlatform> values)
+    {
+        CurrentPage = 1;
+        SelectedPlatforms = values;
         await GetChallenges();
     }
 

--- a/TCSA.V2026/Data/DTOs/Challenges/ChallengeDetails.cs
+++ b/TCSA.V2026/Data/DTOs/Challenges/ChallengeDetails.cs
@@ -1,0 +1,15 @@
+using TCSA.V2026.Data.Enums;
+using TCSA.V2026.Data.Models;
+
+namespace TCSA.V2026.Data.DTOs.Challenges;
+
+public record ChallengeDetails(
+    int Id,
+    string ExternalId,
+    bool IsCompleted,
+    Level Level,
+    string Name,
+    string Description,
+    ChallengeCategory Category,
+    ChallengePlatform Platform,
+    int ExperiencePoints);

--- a/TCSA.V2026/Data/DTOs/Challenges/ChallengeStatistics.cs
+++ b/TCSA.V2026/Data/DTOs/Challenges/ChallengeStatistics.cs
@@ -1,0 +1,3 @@
+namespace TCSA.V2026.Data.DTOs.Challenges;
+
+public record ChallengeStatistics(DailyStreakDetails DailyStreakDetails, int CompletedChallenges);

--- a/TCSA.V2026/Data/DTOs/Challenges/DailyStreakDetails.cs
+++ b/TCSA.V2026/Data/DTOs/Challenges/DailyStreakDetails.cs
@@ -1,0 +1,3 @@
+namespace TCSA.V2026.Data.DTOs.Challenges;
+
+public record DailyStreakDetails(int CurrentStreak, int LongestStreak, DateTime LastCompletedDate);

--- a/TCSA.V2026/Data/DTOs/Challenges/MarkChallengeCompletedRequest.cs
+++ b/TCSA.V2026/Data/DTOs/Challenges/MarkChallengeCompletedRequest.cs
@@ -1,3 +1,3 @@
-namespace TCSA.V2026.Data.DTOs;
+namespace TCSA.V2026.Data.DTOs.Challenges;
 
 public record MarkChallengeCompletedRequest(int ChallengeId, string UserId);

--- a/TCSA.V2026/Data/DTOs/Challenges/SyncChallengeRequest.cs
+++ b/TCSA.V2026/Data/DTOs/Challenges/SyncChallengeRequest.cs
@@ -1,3 +1,3 @@
-namespace TCSA.V2026.Data.DTOs;
+namespace TCSA.V2026.Data.DTOs.Challenges;
 
 public record SyncChallengeRequest(UserPlatformCredentials PlatformCredentials, int ChallengeId, string ExternalId, string UserId);

--- a/TCSA.V2026/Services/Challenges/ChallengeManager.cs
+++ b/TCSA.V2026/Services/Challenges/ChallengeManager.cs
@@ -1,4 +1,4 @@
-using TCSA.V2026.Data.DTOs;
+using TCSA.V2026.Data.DTOs.Challenges;
 using TCSA.V2026.Data.Models;
 using TCSA.V2026.Data.Models.Responses;
 

--- a/TCSA.V2026/Services/Challenges/ChallengeService.cs
+++ b/TCSA.V2026/Services/Challenges/ChallengeService.cs
@@ -1,15 +1,21 @@
-using Microsoft.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using TCSA.V2026.Data;
+using TCSA.V2026.Data.DTOs.Challenges;
 using TCSA.V2026.Data.Enums;
 using TCSA.V2026.Data.Models;
+using TCSA.V2026.Data.Models.Responses;
+using TCSA.V2026.Helpers.Constants;
 
 namespace TCSA.V2026.Services;
 
 public interface IChallengeService
 {
-    Task<List<Challenge>> GetChallenges(Level level);
-    Task<DailyStreak> GetStreakInfo(string userId);
+    Task<PaginatedList<ChallengeDetails>?> GetPaginatedChallenges(int pageNumber,
+        string userId,
+        Level userLevel,
+        bool showCompleted,
+        IEnumerable<Level> selectedLevels,
+        IEnumerable<ChallengeCategory> selectedCategories);
     Task<ChallengeStatistics?> GetChallengeStatistics(string userId);
     Task UpdateStreakInfo(string userId);
 }
@@ -38,36 +44,79 @@ public class ChallengeService(IDbContextFactory<ApplicationDbContext> _factory) 
             {
                 streak.CurrentStreak = 0;
                 await context.SaveChangesAsync();
-        }
+            }
 
             return new ChallengeStatistics(
                 new DailyStreakDetails(streak.CurrentStreak, streak.LongestStreak, streak.LastCompletedDate),
                 data.ChallengeCount
             );
-    }
+        }
         catch (Exception)
         {
             return null;
         }
     }
 
-    public async Task<DailyStreak> GetStreakInfo(string userId)
+    public async Task<PaginatedList<ChallengeDetails>?> GetPaginatedChallenges(
+        int pageNumber,
+        string userId,
+        Level userLevel,
+        bool showCompleted,
+        IEnumerable<Level> selectedLevels,
+        IEnumerable<ChallengeCategory> selectedCategories
+    )
     {
-        using (var context = _factory.CreateDbContext())
+        try
         {
-            var streakInfo = await context.DailyStreaks.FirstOrDefaultAsync(s => s.AppUserId == userId);
+            using var context = _factory.CreateDbContext();
+            var currentUtcDate = DateTime.UtcNow;
+            var query = context.Challenges
+                .Where(c => c.ReleaseDate <= currentUtcDate && c.Level <= userLevel + 1)
+                .AsNoTracking();
 
-            if (streakInfo is null) return new DailyStreak();
-
-            if (streakInfo.CurrentStreak > 0 &&
-                streakInfo.LastCompletedDate < DateTime.UtcNow.Date.AddDays(-1))
+            if (!showCompleted)
             {
-                streakInfo.CurrentStreak = 0;
-                context.DailyStreaks.Update(streakInfo);
-                await context.SaveChangesAsync();
+                query = query.Where(c => !c.UserChallenges.Any(uc => uc.UserId == userId));
             }
 
-            return streakInfo;
+            if (selectedLevels.Any())
+            {
+                query = query.Where(c => selectedLevels.Contains(c.Level));
+            }
+
+            if (selectedCategories.Any())
+            {
+                query = query.Where(c => selectedCategories.Contains(c.Category));
+            }
+
+            var totalItems = await query.CountAsync();
+
+            var items = await query
+                .OrderByDescending(c => c.ReleaseDate)
+                .Skip((pageNumber - 1) * PagingConstants.ChallengesPageSize)
+                .Take(PagingConstants.ChallengesPageSize).Select(c => new ChallengeDetails
+                (
+                    c.Id,
+                    c.ExternalId,
+                    c.UserChallenges.Any(uc => uc.UserId == userId),
+                    c.Level,
+                    c.Name,
+                    c.Description,
+                    c.Category,
+                    c.Platform,
+                    c.ExperiencePoints
+                )).ToListAsync();
+
+            return new PaginatedList<ChallengeDetails>(
+                items,
+                totalItems,
+                pageNumber,
+                PagingConstants.ChallengesPageSize
+            );
+        }
+        catch (Exception)
+        {
+            return null;
         }
     }
 

--- a/TCSA.V2026/Services/Challenges/ChallengeService.cs
+++ b/TCSA.V2026/Services/Challenges/ChallengeService.cs
@@ -10,21 +10,44 @@ public interface IChallengeService
 {
     Task<List<Challenge>> GetChallenges(Level level);
     Task<DailyStreak> GetStreakInfo(string userId);
+    Task<ChallengeStatistics?> GetChallengeStatistics(string userId);
     Task UpdateStreakInfo(string userId);
 }
 
 public class ChallengeService(IDbContextFactory<ApplicationDbContext> _factory) : IChallengeService
 {
-    public async Task<List<Challenge>> GetChallenges(Level level)
+    public async Task<ChallengeStatistics?> GetChallengeStatistics(string userId)
     {
-        using (var context = _factory.CreateDbContext())
+        try
         {
-            var currentUtcDate = DateTime.UtcNow;
-            return await context.Challenges
-                .Where(c => c.ReleaseDate <= currentUtcDate && c.Level <= level + 1)
-                .OrderByDescending(c => c.ReleaseDate)
-                .ToListAsync()
-                .ConfigureAwait(false);
+            using var context = _factory.CreateDbContext();
+            var data = await context.Users
+                .Where(u => u.Id == userId)
+                .Select(u => new
+                {
+                    Streak = u.DailyStreak,
+                    ChallengeCount = u.UserChallenges.Count
+                })
+                .FirstOrDefaultAsync();
+
+            if (data == null) return null;
+
+            var streak = data.Streak;
+
+            if (streak.CurrentStreak > 0 && streak.LastCompletedDate < DateTime.UtcNow.Date.AddDays(-1))
+            {
+                streak.CurrentStreak = 0;
+                await context.SaveChangesAsync();
+        }
+
+            return new ChallengeStatistics(
+                new DailyStreakDetails(streak.CurrentStreak, streak.LongestStreak, streak.LastCompletedDate),
+                data.ChallengeCount
+            );
+    }
+        catch (Exception)
+        {
+            return null;
         }
     }
 

--- a/TCSA.V2026/Services/Challenges/ChallengeService.cs
+++ b/TCSA.V2026/Services/Challenges/ChallengeService.cs
@@ -15,7 +15,8 @@ public interface IChallengeService
         Level userLevel,
         bool showCompleted,
         IEnumerable<Level> selectedLevels,
-        IEnumerable<ChallengeCategory> selectedCategories);
+        IEnumerable<ChallengeCategory> selectedCategories,
+        IEnumerable<ChallengePlatform> selectedPlatforms);
     Task<ChallengeStatistics?> GetChallengeStatistics(string userId);
     Task UpdateStreakInfo(string userId);
 }
@@ -63,7 +64,8 @@ public class ChallengeService(IDbContextFactory<ApplicationDbContext> _factory) 
         Level userLevel,
         bool showCompleted,
         IEnumerable<Level> selectedLevels,
-        IEnumerable<ChallengeCategory> selectedCategories
+        IEnumerable<ChallengeCategory> selectedCategories,
+        IEnumerable<ChallengePlatform> selectedPlatforms
     )
     {
         try
@@ -87,6 +89,11 @@ public class ChallengeService(IDbContextFactory<ApplicationDbContext> _factory) 
             if (selectedCategories.Any())
             {
                 query = query.Where(c => selectedCategories.Contains(c.Category));
+            }
+
+            if (selectedPlatforms.Any())
+            {
+                query = query.Where(c => selectedPlatforms.Contains(c.Platform));
             }
 
             var totalItems = await query.CountAsync();

--- a/TCSA.V2026/Services/Challenges/CodeWarsService.cs
+++ b/TCSA.V2026/Services/Challenges/CodeWarsService.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using System.Net;
 using System.Text.Json;
 using TCSA.V2026.Data;
-using TCSA.V2026.Data.DTOs;
+using TCSA.V2026.Data.DTOs.Challenges;
 using TCSA.V2026.Data.Helpers.ProjectsSubHelpers;
 using TCSA.V2026.Data.Models;
 using TCSA.V2026.Data.Models.Responses;

--- a/TCSA.V2026/Services/Challenges/IChallengePlatformService.cs
+++ b/TCSA.V2026/Services/Challenges/IChallengePlatformService.cs
@@ -1,4 +1,4 @@
-using TCSA.V2026.Data.DTOs;
+using TCSA.V2026.Data.DTOs.Challenges;
 using TCSA.V2026.Data.Models.Responses;
 
 namespace TCSA.V2026.Services.Challenges;

--- a/TCSA.V2026/Services/Challenges/LeetCodeService.cs
+++ b/TCSA.V2026/Services/Challenges/LeetCodeService.cs
@@ -2,7 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using System.Net;
 using System.Text.Json;
 using TCSA.V2026.Data;
-using TCSA.V2026.Data.DTOs;
+using TCSA.V2026.Data.DTOs.Challenges;
 using TCSA.V2026.Data.Models;
 using TCSA.V2026.Data.Models.Responses;
 using TCSA.V2026.Helpers.Constants;

--- a/TCSA.V2026/Services/UserService.cs
+++ b/TCSA.V2026/Services/UserService.cs
@@ -10,7 +10,6 @@ public interface IUserService
 {
     Task<ApplicationUser> GetUserById(string userId);
     Task<ApplicationUser> GetUserForDashboard(string userId);
-    Task<ApplicationUser> GetUserChallengeDetails(string userId);
     Task<ApplicationUser> GetDetailedUserById(string userId);
     Task<ApplicationUser> GetUserProfileById(string userId);
     Task<BaseResponse> SaveProfile(ApplicationUser user);
@@ -244,30 +243,6 @@ public class UserService : IUserService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to retrieve GetUserByIdWithShowcaseItems {UserId}", userId);
-            return null;
-        }
-    }
-
-    public async Task<ApplicationUser> GetUserChallengeDetails(string userId)
-    {
-        try
-        {
-            using (var context = _factory.CreateDbContext())
-            {
-                var user =
-                await context.AspNetUsers
-                .AsNoTracking()
-                .Include(x => x.UserChallenges)
-                    .ThenInclude(x => x.Challenge)
-                .AsSplitQuery()
-                .FirstOrDefaultAsync(x => x.Id.Equals(userId));
-
-                return user;
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to retrieve GetUserChallengeDetails {UserId}", userId);
             return null;
         }
     }


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what this PR does and why. -->
This PR introduces filtering challenges by platform and cleans up the code by moving filtering and pagination logic to the database side.

## Related Issue

<!-- Link the issue this PR resolves. Use "Closes #123" to auto-close it on merge. -->
Closes #389

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [x] New feature
- [x] Refactor (no functional change)
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / configuration
- [ ] Other: <!-- describe -->

## Implementation Details

<!-- Explain key decisions, trade-offs, or non-obvious parts of the implementation. -->
- Moved challenges DTOs to a dedicated folder to group them together
- Applied pagination and sorting entirely on the database side to prevent high memory consumption and severe performance drops
- Unified getting challenge statistics by moving logic for getting completed challenges from `UserService.GetUserChallengeDetails` and streak info from `ChallengeService.GetStreakInfo` into a new `ChallengeService.GetChalllengeStatistics` method. The previous solution resulted in getting challenges twice, once from `ChallengesService.GetChallenges` and again from `UserService.GetUserChallengeDetails`, hence using more memory than it should
- Added filtering by challenge platforms like LeetCode and Codewars
- Updated `ChallengeService` integration tests with the recent additions and introduced new ones testing, for example, filtering by platform

## Testing Performed

<!-- Describe how you tested this change. -->

- [x] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [x] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [x] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [x] Added new tests covering the change
- [x] Manually verified in the browser

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have read the related issue and my implementation matches the requirements
- [x] No sensitive data (credentials, secrets) committed
- [x] All new and existing tests pass
