### PR TITLE
refactor: use async operations in ProjectService

### DIFF
--- a/TCSA.V2026/Services/ProjectService.cs
+++ b/TCSA.V2026/Services/ProjectService.cs
@@ -1,4 +1,3 @@
-﻿using Microsoft.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using TCSA.V2026.Data;
 using TCSA.V2026.Data.Curriculum;
@@ -29,10 +28,10 @@ public class ProjectService(IDbContextFactory<ApplicationDbContext> _factory) : 
         {
             using (var context = _factory.CreateDbContext())
             {
-                var projects = context.DashboardProjects
+                var projects = await context.DashboardProjects
                     .Where(p => p.AppUserId == userId)
                     .Where(p => p.IsPendingNotification)
-                    .ToList();
+                    .ToListAsync();
 
                 foreach (var p in projects)
                 {
@@ -63,8 +62,8 @@ public class ProjectService(IDbContextFactory<ApplicationDbContext> _factory) : 
         {
             using (var context = _factory.CreateDbContext())
             {
-                var project = context.DashboardProjects
-                    .FirstOrDefault(p => p.Id == dashboardProjectId);
+                var project = await context.DashboardProjects
+                    .FirstOrDefaultAsync(p => p.Id == dashboardProjectId);
 
                 if (project == null)
                 {
@@ -272,9 +271,9 @@ public class ProjectService(IDbContextFactory<ApplicationDbContext> _factory) : 
         {
             using (var context = _factory.CreateDbContext())
             {
-                var project = context.DashboardProjects
+                var project = await context.DashboardProjects
                     .Include(dp => dp.AppUser)
-                    .FirstOrDefault(p => p.Id == projectId);
+                    .FirstOrDefaultAsync(p => p.Id == projectId);
 
                 if (project == null)
                 {


### PR DESCRIPTION
## Description

This PR adds missing await keywords and converts synchronous LINQ operations to their async equivalents in `ProjectService.cs`.

## Related Issue

<!-- Link the issue this PR resolves. Use "Closes #123" to auto-close it on merge. -->

Closes #436

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / configuration
- [ ] Other: <!-- describe -->

## Testing Performed

<!-- Describe how you tested this change. -->

- [x] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [x] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [x] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [ ] Added new tests covering the change
- [x] Manually verified in the browser

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have read the related issue and my implementation matches the requirements
- [x] No sensitive data (credentials, secrets) committed
- [x] All new and existing tests pass
