### PR TITLE
feat: add restart onboarding and resume checklist buttons to profile page

### DIFF
--- a/TCSA.V2026.EndToEndTests/EndToEndTestsBase.cs
+++ b/TCSA.V2026.EndToEndTests/EndToEndTestsBase.cs
@@ -24,4 +24,31 @@ public class EndToEndTestsBase : PageTest
         await Page.GetByRole(AriaRole.Button, new() { Name = "Log in", Exact = true }).ClickAsync();
         await Page.WaitForURLAsync($"{BaseUrl}/");
     }
+
+    protected async Task CompleteOnboardingFlowAsync()
+    {
+        var dialog = Page.Locator(".mud-dialog");
+        await dialog.WaitForAsync();
+
+        var getStartedButton = dialog.GetByRole(AriaRole.Button, new() { Name = "Get Started" });
+        var nextButton = dialog.GetByRole(AriaRole.Button, new() { Name = "Next" });
+
+        while (!await getStartedButton.IsVisibleAsync())
+        {
+            await nextButton.ClickAsync();
+        }
+        await getStartedButton.ClickAsync();
+
+        var tour = Page.Locator(".shepherd-element");
+        await tour.WaitForAsync();
+
+        var finishButton = tour.GetByRole(AriaRole.Button, new() { Name = "Finish" });
+        var tourNextButton = tour.GetByRole(AriaRole.Button, new() { Name = "Next" });
+
+        while (!await finishButton.IsVisibleAsync())
+        {
+            await tourNextButton.ClickAsync();
+        }
+        await finishButton.ClickAsync();
+    }
 }

--- a/TCSA.V2026.EndToEndTests/RegisterPageTests.cs
+++ b/TCSA.V2026.EndToEndTests/RegisterPageTests.cs
@@ -26,4 +26,27 @@ public class RegisterPageTests : EndToEndTestsBase
         await Expect(Page).ToHaveURLAsync($"{BaseUrl}/");
         await Expect(Page.GetByText("An account with this email already exists.")).Not.ToBeVisibleAsync();
     }
+
+    [Test]
+    public async Task NewUser_AfterRegistration_CompletesOnboardingFlow()
+    {
+        var email = $"e2e-onboarding-{Guid.NewGuid():N}@example.com";
+
+        await Page.GotoAsync($"{BaseUrl}/Account/Register");
+
+        await Page.GetByLabel("DisplayName").FillAsync("Onboarding User");
+        await Page.GetByLabel("Email").FillAsync(email);
+        await Page.GetByLabel("Password", new() { Exact = true }).FillAsync("Password123!");
+        await Page.GetByLabel("Confirm Password", new() { Exact = true }).FillAsync("Password123!");
+
+        await Page.Locator("#country-select .custom-select-trigger").ClickAsync();
+        await Page.Locator("#country-options .custom-select-option").First.ClickAsync();
+
+        await Page.Locator("form [type='submit']").First.ClickAsync();
+        await Page.WaitForURLAsync($"{BaseUrl}/");
+
+        await CompleteOnboardingFlowAsync();
+
+        await Expect(Page.Locator(".shepherd-element")).Not.ToBeVisibleAsync();
+    }
 }

--- a/TCSA.V2026.UnitTests/Components/Layout/MainLayoutTests.cs
+++ b/TCSA.V2026.UnitTests/Components/Layout/MainLayoutTests.cs
@@ -46,6 +46,7 @@ public class MainLayoutTests : BunitContext
         Services.AddMudServices();
         Services.AddSingleton(_dialogServiceMock.Object);
         Services.AddSingleton(_searchServiceMock.Object);
+        Services.AddScoped<OnboardingStateService>();
 
         AddAuthorization();
     }
@@ -193,5 +194,65 @@ public class MainLayoutTests : BunitContext
                     i.Arguments.Count > 0 &&
                     i.Arguments[0]?.ToString() == "./js/onboarding-tour.js"),
                 Is.True));
+    }
+
+    [Test]
+    public async Task OnboardingStateNotification_WithShowWelcome_ShowsWelcomeDialog()
+    {
+        // Arrange
+        _userServiceMock
+            .Setup(s => s.GetOnboardingStatus(TestUserId))
+            .ReturnsAsync(new OnboardingStatusDto { ShowWelcome = false });
+
+        SetupDialogMock(canceled: true);
+        AuthorizeAs(TestUserId);
+        var cut = RenderMainLayout();
+
+        cut.WaitForAssertion(() =>
+            _userServiceMock.Verify(s => s.GetOnboardingStatus(TestUserId), Times.Once));
+
+        // Act
+        _userServiceMock
+            .Setup(s => s.GetOnboardingStatus(TestUserId))
+            .ReturnsAsync(new OnboardingStatusDto { ShowWelcome = true });
+
+        var onboardingState = Services.GetRequiredService<OnboardingStateService>();
+        await cut.InvokeAsync(() => onboardingState.NotifyChangedAsync());
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            _dialogServiceMock.Verify(
+                s => s.ShowAsync<TCSAWelcomeDialog>(
+                    null,
+                    It.IsAny<DialogParameters<TCSAWelcomeDialog>>(),
+                    It.IsAny<DialogOptions>()),
+                Times.Once));
+    }
+
+    [Test]
+    public async Task OnboardingStateNotification_WithShowChecklist_ShowsChecklistComponent()
+    {
+        // Arrange
+        _userServiceMock
+            .Setup(s => s.GetOnboardingStatus(TestUserId))
+            .ReturnsAsync(new OnboardingStatusDto { ShowChecklist = false });
+
+        AuthorizeAs(TestUserId);
+        var cut = RenderMainLayout();
+
+        cut.WaitForAssertion(() =>
+            _userServiceMock.Verify(s => s.GetOnboardingStatus(TestUserId), Times.Once));
+
+        // Act
+        _userServiceMock
+            .Setup(s => s.GetOnboardingStatus(TestUserId))
+            .ReturnsAsync(new OnboardingStatusDto { ShowChecklist = true, Tasks = [] });
+
+        var onboardingState = Services.GetRequiredService<OnboardingStateService>();
+        await cut.InvokeAsync(() => onboardingState.NotifyChangedAsync());
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            Assert.That(cut.FindComponents<GetStartedChecklist>(), Is.Not.Empty));
     }
 }

--- a/TCSA.V2026.UnitTests/Components/Pages/Dashboard/ProfileTests.cs
+++ b/TCSA.V2026.UnitTests/Components/Pages/Dashboard/ProfileTests.cs
@@ -30,6 +30,15 @@ public class ProfileTests : BunitContext
         Country = "Ireland"
     };
 
+    private readonly ApplicationUser _onboardingUser = new()
+    {
+        Id = TestUserId,
+        DisplayName = "Test User",
+        Country = "Ireland",
+        OnboardingStartedDate = DateTimeOffset.UtcNow,
+        HasDismissedChecklist = true,
+    };
+
     [SetUp]
     public void SetUp()
     {
@@ -45,6 +54,7 @@ public class ProfileTests : BunitContext
         Services.AddSingleton(_projectServiceMock.Object);
         Services.AddSingleton(_userServiceMock.Object);
         Services.AddSingleton(new HttpClient());
+        Services.AddScoped<OnboardingStateService>();
         Services.AddMudServices();
     }
 
@@ -60,6 +70,15 @@ public class ProfileTests : BunitContext
         _userServiceMock
             .Setup(s => s.GetUserProfileById(TestUserId))
             .ReturnsAsync(_testUser);
+
+        return Render<Profile>();
+    }
+
+    private IRenderedComponent<Profile> RenderProfileWithOnboardingUser()
+    {
+        _userServiceMock
+            .Setup(s => s.GetUserProfileById(TestUserId))
+            .ReturnsAsync(_onboardingUser);
 
         return Render<Profile>();
     }
@@ -215,5 +234,127 @@ public class ProfileTests : BunitContext
         // Assert
         var deleteButton = cut.FindAll("button").Single(b => b.TextContent.Contains("Delete Account"));
         Assert.That(deleteButton.HasAttribute("disabled"), Is.True);
+    }
+
+    [Test]
+    public async Task RestartOnboardingButton_WhenClickedTwiceWhileProcessing_CallsRestartOnboardingOnce()
+    {
+        // Arrange
+        var tcs = new TaskCompletionSource<BaseResponse>();
+
+        _userServiceMock
+            .Setup(s => s.RestartOnboarding(TestUserId))
+            .Returns(tcs.Task);
+
+        AuthorizeAs(TestUserId);
+        Render<MudPopoverProvider>();
+        var cut = RenderProfile();
+
+        // Act
+        cut.FindAll("button").Single(b => b.TextContent.Contains("Restart Onboarding")).Click();
+        cut.FindAll("button").Single(b => b.TextContent.Contains("Restart Onboarding")).Click();
+
+        tcs.SetResult(new BaseResponse { Status = ResponseStatus.Success });
+        await cut.InvokeAsync(() => { });
+
+        // Assert
+        _userServiceMock.Verify(s => s.RestartOnboarding(TestUserId), Times.Once);
+    }
+
+    [Test]
+    public void RestartOnboardingButton_WhileProcessing_IsDisabled()
+    {
+        // Arrange
+        var tcs = new TaskCompletionSource<BaseResponse>();
+
+        _userServiceMock
+            .Setup(s => s.RestartOnboarding(TestUserId))
+            .Returns(tcs.Task);
+
+        AuthorizeAs(TestUserId);
+        Render<MudPopoverProvider>();
+        var cut = RenderProfile();
+
+        // Act
+        cut.FindAll("button").Single(b => b.TextContent.Contains("Restart Onboarding")).Click();
+
+        // Assert
+        var button = cut.FindAll("button").Single(b => b.TextContent.Contains("Restart Onboarding"));
+        Assert.That(button.HasAttribute("disabled"), Is.True);
+    }
+
+    [Test]
+    public void ResumeChecklistButton_IsNotVisible_WhenConditionsNotMet()
+    {
+        // Arrange
+        AuthorizeAs(TestUserId);
+        Render<MudPopoverProvider>();
+        var cut = RenderProfile();
+
+        // Assert
+        Assert.That(
+            cut.FindAll("button").Any(b => b.TextContent.Contains("Resume Checklist")),
+            Is.False);
+    }
+
+    [Test]
+    public void ResumeChecklistButton_IsVisible_WhenConditionsMet()
+    {
+        // Arrange
+        AuthorizeAs(TestUserId);
+        Render<MudPopoverProvider>();
+        var cut = RenderProfileWithOnboardingUser();
+
+        // Assert
+        Assert.That(
+            cut.FindAll("button").Any(b => b.TextContent.Contains("Resume Checklist")),
+            Is.True);
+    }
+
+    [Test]
+    public async Task ResumeChecklistButton_WhenClickedTwiceWhileProcessing_CallsResumeChecklistOnce()
+    {
+        // Arrange
+        var tcs = new TaskCompletionSource<BaseResponse>();
+
+        _userServiceMock
+            .Setup(s => s.ResumeChecklist(TestUserId))
+            .Returns(tcs.Task);
+
+        AuthorizeAs(TestUserId);
+        Render<MudPopoverProvider>();
+        var cut = RenderProfileWithOnboardingUser();
+
+        // Act
+        cut.FindAll("button").Single(b => b.TextContent.Contains("Resume Checklist")).Click();
+        cut.FindAll("button").Single(b => b.TextContent.Contains("Resume Checklist")).Click();
+
+        tcs.SetResult(new BaseResponse { Status = ResponseStatus.Success });
+        await cut.InvokeAsync(() => { });
+
+        // Assert
+        _userServiceMock.Verify(s => s.ResumeChecklist(TestUserId), Times.Once);
+    }
+
+    [Test]
+    public void ResumeChecklistButton_WhileProcessing_IsDisabled()
+    {
+        // Arrange
+        var tcs = new TaskCompletionSource<BaseResponse>();
+
+        _userServiceMock
+            .Setup(s => s.ResumeChecklist(TestUserId))
+            .Returns(tcs.Task);
+
+        AuthorizeAs(TestUserId);
+        Render<MudPopoverProvider>();
+        var cut = RenderProfileWithOnboardingUser();
+
+        // Act
+        cut.FindAll("button").Single(b => b.TextContent.Contains("Resume Checklist")).Click();
+
+        // Assert
+        var button = cut.FindAll("button").Single(b => b.TextContent.Contains("Resume Checklist"));
+        Assert.That(button.HasAttribute("disabled"), Is.True);
     }
 }

--- a/TCSA.V2026/Components/Layout/GetStartedChecklist.razor
+++ b/TCSA.V2026/Components/Layout/GetStartedChecklist.razor
@@ -48,6 +48,14 @@
 
     private bool _isDismissing = false;
 
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Tasks.Count > 0 && Tasks.All(t => t.IsCompleted))
+        {
+            await DismissAsync();
+        }
+    }
+
     private async Task DismissAsync()
     {
         _isDismissing = true;

--- a/TCSA.V2026/Components/Layout/MainLayout.razor
+++ b/TCSA.V2026/Components/Layout/MainLayout.razor
@@ -14,6 +14,7 @@
 @inject IDialogService DialogService
 @inject ILogger<MainLayout> Logger
 @inject ISearchService SearchService
+@inject OnboardingStateService OnboardingState
 @implements IAsyncDisposable
 
 <MudThemeProvider Theme="MyCustomTheme" @bind-IsDarkMode="@ThemeService.IsDarkMode" />
@@ -184,6 +185,8 @@
         {
             UserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
         }
+
+        OnboardingState.OnChange += SyncOnboardingStateAsync;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -207,19 +210,7 @@
 
         try
         {
-            if (string.IsNullOrWhiteSpace(UserId))
-            {
-                return;
-            }
-
-            var status = await UserService.GetOnboardingStatus(UserId);
-            _showChecklist = status.ShowChecklist;
-            _checklistTasks = status.Tasks;
-            if (status.ShowWelcome)
-            {
-                await StartOnboardingAsync();
-            }
-            await InvokeAsync(StateHasChanged);
+            await SyncOnboardingStateAsync();
         }
         catch (Exception ex)
         {
@@ -343,8 +334,26 @@
         await UserService.MarkTourCompleted(UserId);
     }
 
+    private async Task SyncOnboardingStateAsync()
+    {
+        if (string.IsNullOrWhiteSpace(UserId)) return;
+
+        var status = await UserService.GetOnboardingStatus(UserId);
+        _showChecklist = status.ShowChecklist;
+        _checklistTasks = status.Tasks;
+
+        if (status.ShowWelcome)
+        {
+            await StartOnboardingAsync();
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
+        OnboardingState.OnChange -= SyncOnboardingStateAsync;
+
         try
         {
             if (_onboardingModule != null)

--- a/TCSA.V2026/Components/Pages/Dashboard/Profile.razor
+++ b/TCSA.V2026/Components/Pages/Dashboard/Profile.razor
@@ -9,6 +9,7 @@
 
 @inject NavigationManager NavigationManager
 @inject IDialogService DialogService
+@inject OnboardingStateService OnboardingState
 
 @attribute [Authorize]
 
@@ -47,13 +48,18 @@
 
         <MudPaper Class="pa-4 mt-5" Elevation="4">
             <h2 class="visually-hidden">Account Actions</h2>
+            <MudButton Variant="Variant.Filled" Color="Color.Info" Disabled="@_isProcessing" OnClick="RestartOnboarding" Class="mt-4">Restart Onboarding</MudButton>
+            @if (ShowResumeChecklist)
+            {
+                <MudButton Variant="Variant.Filled" Color="Color.Secondary" Disabled="@_isProcessing" OnClick="ResumeChecklist" Class="mt-4">Resume Checklist</MudButton>
+            }
             <MudButton Variant="Variant.Filled" Color="Color.Dark" Disabled="@_isProcessing" OnClick="Reset" Class="mt-4">Reset Account</MudButton>
             <MudButton Variant="Variant.Filled" Color="Color.Error" Disabled="@_isProcessing" OnClick="Delete" Class="mt-4">Delete Account</MudButton>
         </MudPaper>
     }
 </MudContainer>
 
-@code {
+    @code {
     [Inject] public HttpClient HttpClient { get; set; } = default!;
     [Inject] private AuthenticationStateProvider AuthenticationState { get; set; }
     [Inject] private IUserService UserService { get; set; }
@@ -67,6 +73,12 @@
     private bool IsLoggedIn = false;
     private bool _isProcessing = false;
     private string UserId;
+
+    private bool ShowResumeChecklist =>
+        User != null &&
+        User.OnboardingStartedDate != null &&
+        User.HasDismissedChecklist &&
+        ChecklistHelper.BuildProfileTasks(User).Any(t => !t.IsCompleted);
 
     protected override async Task OnInitializedAsync()
     {
@@ -99,7 +111,8 @@
             if (result.Status == ResponseStatus.Success)
             {
                 SnackbarService.Add("Profile Updated Successfully", Severity.Success);
-                User = await UserService.GetUserById(UserId);
+                User = await UserService.GetUserProfileById(UserId);
+                await OnboardingState.NotifyChangedAsync();
             }
             else
             {
@@ -171,6 +184,54 @@
                 {
                     SnackbarService.Add($"Error: {apiResult.Message}", Severity.Error);
                 }
+            }
+        }
+        finally
+        {
+            _isProcessing = false;
+        }
+    }
+
+    private async Task RestartOnboarding()
+    {
+        _isProcessing = true;
+
+        try
+        {
+            var result = await UserService.RestartOnboarding(UserId);
+
+            if (result.Status == ResponseStatus.Success)
+            {
+                User = await UserService.GetUserById(UserId);
+                await OnboardingState.NotifyChangedAsync();
+            }
+            else
+            {
+                SnackbarService.Add($"Error: {result.Message}", Severity.Error);
+            }
+        }
+        finally
+        {
+            _isProcessing = false;
+        }
+    }
+
+    private async Task ResumeChecklist()
+    {
+        _isProcessing = true;
+
+        try
+        {
+            var result = await UserService.ResumeChecklist(UserId);
+
+            if (result.Status == ResponseStatus.Success)
+            {
+                User = await UserService.GetUserById(UserId);
+                await OnboardingState.NotifyChangedAsync();
+            }
+            else
+            {
+                SnackbarService.Add($"Error: {result.Message}", Severity.Error);
             }
         }
         finally

--- a/TCSA.V2026/Program.cs
+++ b/TCSA.V2026/Program.cs
@@ -88,6 +88,7 @@ builder.Services.AddControllers();
 
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<ThemeService>();
+builder.Services.AddScoped<OnboardingStateService>();
 
 builder.Services.AddDiscordGateway(options =>
 {

--- a/TCSA.V2026/Services/OnboardingStateService.cs
+++ b/TCSA.V2026/Services/OnboardingStateService.cs
@@ -1,0 +1,12 @@
+namespace TCSA.V2026.Services;
+
+public class OnboardingStateService
+{
+    public event Func<Task>? OnChange;
+
+    public async Task NotifyChangedAsync()
+    {
+        if (OnChange != null)
+            await OnChange.Invoke();
+    }
+}

--- a/TCSA.V2026/Services/OnboardingStateService.cs
+++ b/TCSA.V2026/Services/OnboardingStateService.cs
@@ -6,7 +6,14 @@ public class OnboardingStateService
 
     public async Task NotifyChangedAsync()
     {
-        if (OnChange != null)
-            await OnChange.Invoke();
+        if (OnChange == null) return;
+
+        foreach (var handler in OnChange.GetInvocationList())
+        {
+            if (handler is Func<Task> asyncHandler)
+            {
+                await asyncHandler.Invoke();
+            }
+        }
     }
 }

--- a/TCSA.V2026/Services/UserService.cs
+++ b/TCSA.V2026/Services/UserService.cs
@@ -25,6 +25,8 @@ public interface IUserService
     Task<BaseResponse> MarkWelcomeSeen(string userId);
     Task<BaseResponse> MarkTourCompleted(string userId);
     Task<BaseResponse> MarkChecklistDismissed(string userId);
+    Task<BaseResponse> RestartOnboarding(string userId);
+    Task<BaseResponse> ResumeChecklist(string userId);
 }
 
 public class UserService : IUserService
@@ -371,6 +373,25 @@ public class UserService : IUserService
             user.HasDismissedChecklist = true;
         });
     }
+
+    public Task<BaseResponse> RestartOnboarding(string userId)
+    {
+        return UpdateOnboardingFlag(userId, user =>
+        {
+            user.HasCompletedWelcome = false;
+            user.HasCompletedTour = false;
+            user.OnboardingStartedDate = DateTime.UtcNow;
+        });
+    }
+
+    public Task<BaseResponse> ResumeChecklist(string userId)
+    {
+        return UpdateOnboardingFlag(userId, user =>
+        {
+            user.HasDismissedChecklist = false;
+        });
+    }
+
     private async Task<BaseResponse> UpdateOnboardingFlag(string userId, Action<ApplicationUser> applyUpdate)
     {
         try


### PR DESCRIPTION
## Description

This PR adds "Restart Onboarding" and "Resume Checklist" buttons to the Profile page, allowing users to re-enter the onboarding flow or restore a previously dismissed checklist.

## Related Issue

<!-- Link the issue this PR resolves. Use "Closes #123" to auto-close it on merge. -->

Closes #443

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / configuration
- [ ] Other: <!-- describe -->

## Implementation Details
- Added `OnboardingStateService` to notify `MainLayout` when the user triggers `ResumeChecklist`, `RestartOnboarding`, or `Save`, allowing it to refetch data and update UI without requiring a full page reload.
- The `Resume Checklist` button only shows up when onboarding has been started, the checklist was dismissed, and at least one task remains incomplete.
- Added new tests in `ProfileTests.cs` to verify button behavior (double-click prevention, disabled while processing, visibility conditions)
- Added new tests in `MainLayoutTests.cs` to verify that `OnboardingStateService.NotifyChangedAsync()` causes `MainLayout` to display welcome dialog and checklist components.
- Added missing E2E test to verify that onboarding flow works correctly when a new user registers. 

## Testing Performed

<!-- Describe how you tested this change. -->

- [x] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [x] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [x] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [x] Added new tests covering the change
- [x] Manually verified in the browser

## Preview
https://www.loom.com/share/4ac4a02dbcdb412d863889b0bcdd3294

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have read the related issue and my implementation matches the requirements
- [x] No sensitive data (credentials, secrets) committed
- [x] All new and existing tests pass