### PR TITLE
fix: resolve footer styling issues

### DIFF
--- a/TCSA.V2026/Components/Layout/MainLayout.razor
+++ b/TCSA.V2026/Components/Layout/MainLayout.razor
@@ -43,7 +43,6 @@
                          Dense="true"
                          Margin="Margin.Dense"
                          Variant="Variant.Outlined"
-                         Style="max-width: 320px"
                          Class="ml-4 appbar-search"
                          AdornmentColor="Color.Primary">
             <ItemTemplate Context="item">
@@ -103,56 +102,51 @@
     <MudMainContent Class="pt-16 pb-16">
         @Body
     </MudMainContent>
+    <div class="fixed py-3 px-4" style="bottom: 0; left: 0; right: 0; background-color: var(--mud-palette-background); border-top: 1px solid var(--mud-palette-divider); z-index: 1000;">
+        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Spacing="2">
+            <MudStack Row="true" Spacing="1">
+                <MudLink Href="about" Underline="Underline.None" Class="d-flex align-center py-2 px-1 px-sm-3">
+                    <MudIcon Icon="@Icons.Material.Filled.Info" Size="Size.Small" Class="mr-2" />
+                    <MudText Typo="Typo.body2">About</MudText>
+                </MudLink>
+                <MudLink Href="contact" Underline="Underline.None" Class="d-flex align-center py-2 px-1 px-sm-3">
+                    <MudIcon Icon="@Icons.Material.Filled.Mail" Size="Size.Small" Class="mr-2" />
+                    <MudText Typo="Typo.body2">Contact</MudText>
+                </MudLink>
+                <MudLink Href="privacy" Underline="Underline.None" Class="d-flex align-center py-2 px-1 px-sm-3">
+                    <MudIcon Icon="@Icons.Material.Filled.Security" Size="Size.Small" Class="mr-2" />
+                    <MudText Typo="Typo.body2">Privacy</MudText>
+                </MudLink>
+            </MudStack>
+            <MudStack Row="true" Justify="Justify.Center" Spacing="1">
+                <MudLink Color="Color.Primary"
+                         Href="@LinkOptions.Value.Discord"
+                         Target="_blank"
+                         Class="mud-icon-button mud-button-root pa-1"
+                         UserAttributes="@(new() { ["aria-label"] = "Discord", ["rel"] = "noopener noreferrer" })">
+                    <MudIcon Icon=@Icons.Custom.Brands.Discord Size="Size.Small"
+                             UserAttributes="@(new() { ["aria-hidden"] = "true" })" />
+                </MudLink>
+                <MudLink Color="Color.Primary"
+                         Href="@LinkOptions.Value.Youtube"
+                         Target="_blank"
+                         Class="mud-icon-button mud-button-root pa-1"
+                         UserAttributes="@(new() { ["aria-label"] = "YouTube", ["rel"] = "noopener noreferrer" })">
+                    <MudIcon Icon=@Icons.Custom.Brands.YouTube Size="Size.Small"
+                             UserAttributes="@(new() { ["aria-hidden"] = "true" })" />
+                </MudLink>
+                <MudLink Color="Color.Primary"
+                         Href="@LinkOptions.Value.Linkedin"
+                         Target="_blank"
+                         Class="mud-icon-button mud-button-root pa-1"
+                         UserAttributes="@(new() { ["aria-label"] = "LinkedIn", ["rel"] = "noopener noreferrer" })">
+                    <MudIcon Icon=@Icons.Custom.Brands.LinkedIn Size="Size.Small"
+                             UserAttributes="@(new() { ["aria-hidden"] = "true" })" />
+                </MudLink>
+            </MudStack>
+        </MudStack>
+    </div>
 </MudLayout>
-
-<!-- Fixed Footer Bar -->
-<div style="position: fixed; bottom: 0; left: 0; right: 0; background-color: var(--mud-palette-background); border-top: 1px solid var(--mud-palette-divider); z-index: 10000; padding: 12px 16px;">
-    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Spacing="2">
-        <MudStack Row="true" Spacing="1">
-            <MudLink Href="about" Underline="Underline.None" Class="d-flex align-center" Style="padding: 8px 12px;">
-                <MudIcon Icon="@Icons.Material.Filled.Info" Size="Size.Small" Class="mr-2" />
-                <MudText Typo="Typo.body2">About</MudText>
-            </MudLink>
-            <MudLink Href="contact" Underline="Underline.None" Class="d-flex align-center" Style="padding: 8px 12px;">
-                <MudIcon Icon="@Icons.Material.Filled.Mail" Size="Size.Small" Class="mr-2" />
-                <MudText Typo="Typo.body2">Contact</MudText>
-            </MudLink>
-            <MudLink Href="privacy" Underline="Underline.None" Class="d-flex align-center" Style="padding: 8px 12px;">
-                <MudIcon Icon="@Icons.Material.Filled.Security" Size="Size.Small" Class="mr-2" />
-                <MudText Typo="Typo.body2">Privacy</MudText>
-            </MudLink>
-        </MudStack>
-        <MudStack Row="true" Justify="Justify.Center" Spacing="1">
-            <MudLink Color="Color.Primary"
-                     Href="@LinkOptions.Value.Discord"
-                     Target="_blank"
-                     Class="mud-icon-button mud-button-root"
-                     UserAttributes="@(new() { ["aria-label"] = "Discord", ["rel"] = "noopener noreferrer" })"
-                     Style="padding: 4px;">
-                <MudIcon Icon=@Icons.Custom.Brands.Discord Size="Size.Small"
-                         UserAttributes="@(new() { ["aria-hidden"] = "true" })" />
-            </MudLink>
-            <MudLink Color="Color.Primary"
-                     Href="@LinkOptions.Value.Youtube"
-                     Target="_blank"
-                     Class="mud-icon-button mud-button-root"
-                     UserAttributes="@(new() { ["aria-label"] = "YouTube", ["rel"] = "noopener noreferrer" })"
-                     Style="padding: 4px;">
-                <MudIcon Icon=@Icons.Custom.Brands.YouTube Size="Size.Small"
-                         UserAttributes="@(new() { ["aria-hidden"] = "true" })" />
-            </MudLink>
-            <MudLink Color="Color.Primary"
-                     Href="@LinkOptions.Value.Linkedin"
-                     Target="_blank"
-                     Class="mud-icon-button mud-button-root"
-                     UserAttributes="@(new() { ["aria-label"] = "LinkedIn", ["rel"] = "noopener noreferrer" })"
-                     Style="padding: 4px;">
-                <MudIcon Icon=@Icons.Custom.Brands.LinkedIn Size="Size.Small"
-                         UserAttributes="@(new() { ["aria-hidden"] = "true" })" />
-            </MudLink>
-        </MudStack>
-    </MudStack>
-</div>
 
 @if (string.IsNullOrEmpty(Nav.ToBaseRelativePath(Nav.Uri)) && !_showChecklist)
 {
@@ -161,7 +155,7 @@
         {
             <MudFab StartIcon="@(_feedOpen? Icons.Material.Filled.Close : Icons.Material.Filled.Feed)"
                     Color="Color.Primary"
-                    Style="position: fixed; bottom: 32px; right: 32px; z-index: 1305;"
+                    Class="fixed" Style="bottom: 64px; right: 32px; z-index: 1305;"
                     OnClick="@ToggleFeedDrawer"
                     aria-label="Toggle News Feed"
                     Title="@(_feedOpen ? "Close News Feed" : "Open News Feed")" />
@@ -170,7 +164,7 @@
     <MudHidden Breakpoint="Breakpoint.SmAndDown">
         <MudFab StartIcon="@(_feedOpen? Icons.Material.Filled.Close : Icons.Material.Filled.Feed)"
                 Color="Color.Primary"
-                Style="position: fixed; bottom: 32px; right: 32px; z-index: 1305;"
+                Class="fixed" Style="bottom: 64px; right: 32px; z-index: 1305;"
                 OnClick="@ToggleFeedDrawer"
                 aria-label="Toggle News Feed"
                 Title="@(_feedOpen ? "Close News Feed" : "Open News Feed")" />
@@ -183,7 +177,7 @@
         {
             <MudFab StartIcon="@(_checklistOpen ? Icons.Material.Filled.Close : Icons.Material.Filled.Checklist)"
                     Color="Color.Primary"
-                    Style="position: fixed; bottom: 32px; right: 32px; z-index: 1305;"
+                    Class="fixed" Style="bottom: 64px; right: 32px; z-index: 1305;"
                     OnClick="@ToggleChecklistDrawer"
                     aria-label="Toggle Getting Started Checklist"
                     Title="@(_checklistOpen ? "Close Checklist" : "Open Getting Started Checklist")" />
@@ -192,7 +186,7 @@
     <MudHidden Breakpoint="Breakpoint.SmAndDown">
         <MudFab StartIcon="@(_checklistOpen ? Icons.Material.Filled.Close : Icons.Material.Filled.Checklist)"
                 Color="Color.Primary"
-                Style="position: fixed; bottom: 32px; right: 32px; z-index: 1305;"
+                Class="fixed" Style="bottom: 64px; right: 32px; z-index: 1305;"
                 OnClick="@ToggleChecklistDrawer"
                 aria-label="Toggle Getting Started Checklist"
                 Title="@(_checklistOpen ? "Close Checklist" : "Open Getting Started Checklist")" />

--- a/TCSA.V2026/wwwroot/css/site.css
+++ b/TCSA.V2026/wwwroot/css/site.css
@@ -85,6 +85,10 @@ html, body {
     color: white !important;
 }
 
+.appbar-search {
+    max-width: 320px;
+}
+
 .appbar-search .mud-input-slot {
     color: white !important;
 }


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what this PR does and why. -->
This PR resolves footer overlap issues with notifications, FAB, and dialog interactivity.

## Related Issue

<!-- Link the issue this PR resolves. Use "Closes #123" to auto-close it on merge. -->

Closes #447

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / configuration
- [ ] Other: <!-- describe -->

## Implementation Details

<!-- Explain key decisions, trade-offs, or non-obvious parts of the implementation. -->
- Updated the footer's z-index to prevent overlapping issues
- Added responsive padding on mobile devices to prevent content overflow
- Moved CSS styles from inline style attributes to appropriate MudBlazor classes

## Testing Performed

<!-- Describe how you tested this change. -->

- [x] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [x] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [x] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [ ] Added new tests covering the change
- [x] Manually verified in the browser

## Screenshots
<img width="1869" height="222" alt="notification_after" src="https://github.com/user-attachments/assets/b45e23cf-5f70-40ae-9698-e8b7e31cf0bd" />
<img width="1872" height="900" alt="after" src="https://github.com/user-attachments/assets/aaeb8fce-f32f-4893-a229-eb9a477e50af" />

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have read the related issue and my implementation matches the requirements
- [x] No sensitive data (credentials, secrets) committed
- [x] All new and existing tests pass