### PR TITLE
fix: typo from "We APIs" to "Web APIs"

### DIFF
--- a/TCSA.V2026/Data/Curriculum/Courses/WebApiCourse.cs
+++ b/TCSA.V2026/Data/Curriculum/Courses/WebApiCourse.cs
@@ -41,7 +41,7 @@ public class WebApiCourse
                             },
                             new Block
                             {
-                                Title = "What are We APIs?",
+                                Title = "What are Web APIs?",
                                 Paragraphs = new List<Paragraph>
                                 {
                                     new Paragraph {


### PR DESCRIPTION
## Description

Fixes a typo, "We APIs", to "Web APIs" in the introduction page of ASP.NET Core Web APIs course.

## Related Issue

https://github.com/the-csharp-academy/TCSA.V2026/issues/454

Closes #454 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / configuration
- [x] Other: Text correction

## Implementation Details

Single character typo correction, no logic or behavior change.

## Testing Performed

- [ ] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [ ] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [ ] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [ ] Added new tests covering the change
- [x] Manually verified in the browser

## Additional Context

None.
