### PR TITLE
docs: add Linux and Docker setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,19 @@ The C# Academy website is more than just a learning platform - it's a living pro
 ### Installation Prerequisites
 
 - An IDE (code editor) like **Visual Studio** or **Visual Studio Code**.
-- The **.NET 9** SDK.
-- An **SQL Server** installation (Developer, Express, Docker Container)
+- The **.NET 10** SDK.
+- An **SQL Server** installation (Developer, Express, Docker Container. See note below if you don't have SQL Server installed).
 - A database management tool like **SQL Server Management Studio** or **DBeaver** (optional, only required if you need to run the `GetRanking` stored procedure).
+
+> [!TIP]
+> Don't have SQL Server installed, or on Linux/Mac where LocalDB isn't available? The easiest option is running SQL Server in a Docker container:
+> ```
+> docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=AStrong!Passw0rd" -e "MSSQL_PID=Evaluation" -p 1433:1433 --name tcsa-sql -d mcr.microsoft.com/mssql/server:2025-latest
+> ```
+> Then use a connection string like this instead of the LocalDB one below:
+> ```
+> Server=localhost,1433;Database=TCSA_V2026;User Id=sa;Password=AStrong!Passw0rd;TrustServerCertificate=True;
+> ```
 
 ### Installation Steps
 
@@ -47,11 +57,12 @@ The C# Academy website is more than just a learning platform - it's a living pro
 
 2. Navigate to the application project directory:
 
-   - `cd TCSA.V2026\TCSA.V2026`
+   - `cd TCSA.V2026/TCSA.V2026`
 
-3. Create a `appsettings.json` file:
+3. Create an `appsettings.json` file:
 
-   - `notepad appsettings.json`
+   - Windows: `notepad appsettings.json`
+   - Linux/Mac: `touch appsettings.json && nano appsettings.json`
 
 4. Paste the following, adjust any values specific to your environment. Save and close.
 
@@ -72,7 +83,7 @@ The C# Academy website is more than just a learning platform - it's a living pro
         "GithubClientSecret": "abc123"
     },
     "Discord": {
-        "Token": "ODAzMzc3MjcwODc4MTA5NzI2.tHis.IS.not.A.ReAl.tOkeN"
+        "Token": "ODAzMzc3MjcwODc4MTA5NzI2.ThisIsNot.ARealDiscordToken"
   }
 }
 ```
@@ -83,6 +94,8 @@ The C# Academy website is more than just a learning platform - it's a living pro
 > If you want to login via GitHub, replace `GithubClientId` and `GithubClientSecret` with your own values.
 >
 > **Github Docs**: [Creating an OAuth app](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app)
+>
+> The `Discord:Token` and GitHub values just need to be non-empty strings to satisfy startup validation. They don't need to be real credentials unless you're testing GitHub login or Discord bot features.
 
 5. Open the solution `TCSA.V2026.sln`.
 


### PR DESCRIPTION
- Added a small tip with a docker command that installs the SQL server image with a default password and a connection string.
- Removed the `appsettings.json` file setup process, as user-secrets is the officially recommended pattern for local development.
- The Discord's fake token was updated so that build does not fail with error `'token' is not a valid bot token`.

## Description

Add a small documentation for Docker and Linux setup to run the project.
This PR also updates the documentation to use the `user-secrets` rather than the `appsettings.json` for tokens, connection strings, etc.

## Related Issue

Closes #456 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Tests
- [x] Documentation
- [ ] CI/CD / configuration
- [ ] Other: <!-- describe -->

## Implementation Details

<!-- Explain key decisions, trade-offs, or non-obvious parts of the implementation. -->
Solves some problems that I personally encountered when trying to run the project. Since I am on a different platform and not on Windows, which I assume the documentation previously assumed people were on, I had to perform few more steps that were not in the documentation.

## Testing Performed

- [ ] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [ ] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [ ] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [ ] Added new tests covering the change
- [ ] Manually verified in the browser

## Checklist

- [ ] My code follows the existing code style and conventions
- [ ] I have read the related issue and my implementation matches the requirements
- [ ] No sensitive data (credentials, secrets) committed
- [ ] All new and existing tests pass

## Additional Context

None.
