### PR TITLE
refactor(PeerReview): improve PeerReviewService execution #437

### DIFF
--- a/TCSA.V2026/Services/PeerReviewService.cs
+++ b/TCSA.V2026/Services/PeerReviewService.cs
@@ -13,7 +13,6 @@ namespace TCSA.V2026.Services;
 public interface IPeerReviewService
 {
     Task<List<CodeReviewDetail>> GetCodeReviewDetails(string userId);
-    Task<ApplicationUser> GetUserForPeerReview(string reviewerId);
     Task<List<PeerReviewDisplay>> GetProjectsForPeerReview(string userId);
     Task<BaseResponse> AssignUserToCodeReview(string userId, int id);
     Task<BaseResponse> ReleaseUserFromCodeReview(string userId, int id);
@@ -88,23 +87,6 @@ public class PeerReviewService(IDbContextFactory<ApplicationDbContext> _factory)
         }
     }
 
-    public async Task<ApplicationUser> GetUserForPeerReview(string reviewerId)
-    {
-        try
-        {
-            using (var context = _factory.CreateDbContext())
-            {
-                return await context.AspNetUsers
-                    .Include(x => x.CodeReviewProjects)
-                    .FirstOrDefaultAsync(x => x.Id.Equals(reviewerId));
-            }
-        }
-        catch (Exception ex)
-        {
-            return null;
-        }
-    }
-
     public async Task<List<PeerReviewDisplay>> GetProjectsForPeerReview(string userId)
     {
         var validUrls = new[]
@@ -131,7 +113,7 @@ public class PeerReviewService(IDbContextFactory<ApplicationDbContext> _factory)
                 List<int> eligibleProjectIds =
                     PeerReviewHelpers.DetermineReviewableProjectIds(user.Level, user.DashboardProjects.Select(dp => dp.ProjectId));
 
-                var assignedProjectIds = context.UserReviews
+                var assignedProjectIds = await context.UserReviews
                     .Where(x => x.AppUserId != user.Id)
                     .Select(x => x.DashboardProjectId);
 


### PR DESCRIPTION
- Removed the unused `GetUserForPeerReview` method from both `IPeerReviewService` and `PeerReviewService`.
- Added the missing `await` operator to the `assignedProjectIds` query in `GetProjectsForPeerReview` to ensure proper asynchronous execution.

## Description

<!-- A clear and concise description of what this PR does and why. -->

## Related Issue

<!-- Link the issue this PR resolves. Use "Closes #123" to auto-close it on merge. -->

**Related Issue**
Closes #437

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / configuration
- [ ] Other: <!-- describe -->

## Implementation Details

<!-- Explain key decisions, trade-offs, or non-obvious parts of the implementation. -->

## Testing Performed

<!-- Describe how you tested this change. -->

- [ ] Ran existing unit tests (`dotnet test TCSA.V2026.UnitTests/`)
- [ ] Ran existing integration tests (`dotnet test TCSA.2026.IntegrationTests/`)
- [ ] Ran existing end-to-end tests (`dotnet test TCSA.2026.EndToEndTests/`)
- [ ] Added new tests covering the change
- [ ] Manually verified in the browser

## Screenshots

<!-- If this PR affects the UI, include before/after screenshots or a screen recording. Remove this section if not applicable. -->

| Before | After |
|--------|-------|
|        |       |

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have read the related issue and my implementation matches the requirements
- [x] No sensitive data (credentials, secrets) committed
- [ ] All new and existing tests pass

## Additional Context

<!-- Anything else reviewers should know: related PRs, migration notes, deployment considerations, etc. -->
